### PR TITLE
style(web): mobile + desktop UI/UX & accessibility overhaul

### DIFF
--- a/website/src/app/agents/page.tsx
+++ b/website/src/app/agents/page.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
 import { TerminalWindow } from '@/components/TerminalWindow';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 import { ApiClient } from '@/lib/api';
 
 interface AgentFromApi {
@@ -91,18 +92,18 @@ function AgentCard({ agent, index, phase, onClick }: AgentCardProps) {
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.02 }}
-      onClick={onClick}
+      {...clickableProps(onClick, agent.name)}
       className={`card-cli p-3 border ${colors.border} hover:border-opacity-100 transition-all cursor-pointer hover:bg-[#21262d]/50`}
     >
       <div className="flex items-start justify-between mb-2">
         <div>
           <span className={`${colors.accent} text-xs font-bold`}>{agent.name}</span>
-          <div className="text-[10px] text-[#6b7280]">{agent.role}</div>
+          <div className="text-[10px] text-[#8b949e]">{agent.role}</div>
         </div>
         <div className="status-dot online" style={{ width: 6, height: 6 }} />
       </div>
       {expertise && (
-        <div className="text-[10px] text-[#6b7280] mb-2">
+        <div className="text-[10px] text-[#8b949e] mb-2">
           <span className="text-[#bd93f9]">expertise:</span> {expertise}
         </div>
       )}
@@ -203,7 +204,7 @@ export default function AgentsPage() {
           <h1 className="text-[#39ff14] text-xl font-bold glow-green">
             {t('agents.pageTitle').toUpperCase()}
           </h1>
-          <p className="text-[#6b7280] text-xs mt-1">
+          <p className="text-[#8b949e] text-xs mt-1">
             {t('agents.pageSubtitle')}
             {usingFallback && <span className="text-[#f1fa8c] ml-2">{t('agents.cachedData')}</span>}
           </p>
@@ -230,9 +231,9 @@ export default function AgentsPage() {
                   <div className="flex items-center gap-2 mb-2">
                     <span className="tag tag-cyan">{t('agents.phaseNum.1')}</span>
                     <span className="text-[#00ffff] text-xs font-bold">{t('agents.phase.divergence')}</span>
-                    <span className="text-[#6b7280] text-xs">- {t('agents.phaseDesc.divergence')} ({divergenceAgents.length} {t('agents.agents')})</span>
+                    <span className="text-[#8b949e] text-xs">- {t('agents.phaseDesc.divergence')} ({divergenceAgents.length} {t('agents.agents')})</span>
                   </div>
-                  <p className="text-[10px] text-[#6b7280]">
+                  <p className="text-[10px] text-[#8b949e]">
                     {t('agents.phaseInfo.divergence')}
                   </p>
                 </div>
@@ -262,9 +263,9 @@ export default function AgentsPage() {
                   <div className="flex items-center gap-2 mb-2">
                     <span className="tag tag-purple">{t('agents.phaseNum.2')}</span>
                     <span className="text-[#bd93f9] text-xs font-bold">{t('agents.phase.convergence')}</span>
-                    <span className="text-[#6b7280] text-xs">- {t('agents.phaseDesc.convergence')} ({convergenceAgents.length} {t('agents.agents')})</span>
+                    <span className="text-[#8b949e] text-xs">- {t('agents.phaseDesc.convergence')} ({convergenceAgents.length} {t('agents.agents')})</span>
                   </div>
-                  <p className="text-[10px] text-[#6b7280]">
+                  <p className="text-[10px] text-[#8b949e]">
                     {t('agents.phaseInfo.convergence')}
                   </p>
                 </div>
@@ -294,9 +295,9 @@ export default function AgentsPage() {
                   <div className="flex items-center gap-2 mb-2">
                     <span className="tag tag-green">{t('agents.phaseNum.3')}</span>
                     <span className="text-[#39ff14] text-xs font-bold">{t('agents.phase.planning')}</span>
-                    <span className="text-[#6b7280] text-xs">- {t('agents.phaseDesc.planning')} ({planningAgents.length} {t('agents.agents')})</span>
+                    <span className="text-[#8b949e] text-xs">- {t('agents.phaseDesc.planning')} ({planningAgents.length} {t('agents.agents')})</span>
                   </div>
-                  <p className="text-[10px] text-[#6b7280]">
+                  <p className="text-[10px] text-[#8b949e]">
                     {t('agents.phaseInfo.planning')}
                   </p>
                 </div>
@@ -328,13 +329,13 @@ export default function AgentsPage() {
                 <div className="space-y-3">
                   <div>
                     <span className="text-[#00ffff] text-xs font-bold">{t('agents.thinkingStyle')}</span>
-                    <div className="text-[10px] text-[#6b7280] mt-1">
+                    <div className="text-[10px] text-[#8b949e] mt-1">
                       <span className="text-[#39ff14]">{t('agents.optimistic')}</span> vs <span className="text-[#ff5555]">{t('agents.cautious')}</span>
                     </div>
                   </div>
                   <div>
                     <span className="text-[#bd93f9] text-xs font-bold">{t('agents.decisionStyle')}</span>
-                    <div className="text-[10px] text-[#6b7280] mt-1">
+                    <div className="text-[10px] text-[#8b949e] mt-1">
                       <span className="text-[#f1fa8c]">{t('agents.intuitive')}</span> vs <span className="text-[#00ffff]">{t('agents.analytical')}</span>
                     </div>
                   </div>
@@ -342,13 +343,13 @@ export default function AgentsPage() {
                 <div className="space-y-3">
                   <div>
                     <span className="text-[#ff6b35] text-xs font-bold">{t('agents.communicationStyle')}</span>
-                    <div className="text-[10px] text-[#6b7280] mt-1">
+                    <div className="text-[10px] text-[#8b949e] mt-1">
                       <span className="text-[#ff6b35]">{t('agents.challenger')}</span> vs <span className="text-[#39ff14]">{t('agents.supporter')}</span>
                     </div>
                   </div>
                   <div>
                     <span className="text-[#f1fa8c] text-xs font-bold">{t('agents.actionStyle')}</span>
-                    <div className="text-[10px] text-[#6b7280] mt-1">
+                    <div className="text-[10px] text-[#8b949e] mt-1">
                       <span className="text-[#bd93f9]">{t('agents.innovative')}</span> vs <span className="text-[#c0c0c0]">{t('agents.pragmatic')}</span>
                     </div>
                   </div>

--- a/website/src/app/backlog/page.tsx
+++ b/website/src/app/backlog/page.tsx
@@ -122,7 +122,7 @@ export default function BacklogPage() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1 }}
-          className="mb-6 flex gap-2 border-b border-zinc-800 pb-4"
+          className="mb-6 flex flex-wrap md:flex-nowrap gap-2 border-b border-zinc-800 pb-4"
         >
           {tabs.map((tab) => (
             <button

--- a/website/src/app/debates/page.tsx
+++ b/website/src/app/debates/page.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/lib/i18n';
 import { ApiClient, type ApiDebate } from '@/lib/api';
 import { formatLocalDateTime } from '@/lib/date';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 import { TerminalWindow, TerminalBadge } from '@/components/TerminalWindow';
 
 // Polling interval: 5 seconds for active debates, 30 seconds otherwise
@@ -120,7 +121,7 @@ export default function DebatesPage() {
               </motion.div>
             )}
           </div>
-          <p className="text-sm text-[#6b7280]">
+          <p className="text-sm text-[#8b949e]">
             {t('debates.pageSubtitle')}
           </p>
         </motion.div>
@@ -143,11 +144,11 @@ export default function DebatesPage() {
               >
                 <div className="text-3xl mb-2">{agent.icon}</div>
                 <div className={`text-sm font-bold ${agent.color}`}>{agent.role}</div>
-                <div className="text-[10px] text-[#6b7280] mt-1">{agent.desc}</div>
+                <div className="text-[10px] text-[#8b949e] mt-1">{agent.desc}</div>
               </motion.div>
             ))}
           </div>
-          <div className="text-center text-xs text-[#6b7280] border-t border-[#21262d] pt-4">
+          <div className="text-center text-xs text-[#8b949e] border-t border-[#21262d] pt-4">
             Agents rotate through roles: <span className="text-[#00ffff]">Proposer</span> →
             <span className="text-[#39ff14]"> Supporter</span> →
             <span className="text-[#ff6b35]"> Challenger</span> →
@@ -177,7 +178,7 @@ export default function DebatesPage() {
                   `}>
                     {item.phase}
                   </div>
-                  <div className="text-[10px] text-[#6b7280] mt-1">{item.desc}</div>
+                  <div className="text-[10px] text-[#8b949e] mt-1">{item.desc}</div>
                 </div>
                 {idx < 2 && (
                   <span className="text-[#21262d] mx-2 hidden md:block">→</span>
@@ -191,7 +192,7 @@ export default function DebatesPage() {
         <TerminalWindow title="FILTERS" className="mb-6">
           <div className="flex flex-wrap gap-4 items-end">
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('debates.filter.status')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('debates.filter.status')}</label>
               <select
                 value={filter.status || ''}
                 onChange={(e) => setFilter({ ...filter, status: e.target.value || undefined })}
@@ -204,7 +205,7 @@ export default function DebatesPage() {
               </select>
             </div>
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('debates.filter.phase')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('debates.filter.phase')}</label>
               <select
                 value={filter.phase || ''}
                 onChange={(e) => setFilter({ ...filter, phase: e.target.value || undefined })}
@@ -219,7 +220,7 @@ export default function DebatesPage() {
 
             {/* Polling Status */}
             <div className="ml-auto text-right">
-              <div className="text-[10px] text-[#6b7280]">
+              <div className="text-[10px] text-[#8b949e]">
                 {hasActiveDebate ? (
                   <span className="text-[#ff6b35]">
                     <span className="inline-block w-2 h-2 rounded-full bg-[#ff6b35] animate-pulse mr-1" />
@@ -248,7 +249,7 @@ export default function DebatesPage() {
           ) : debates.length === 0 ? (
             <div className="text-center py-12">
               <div className="text-4xl mb-4">💬</div>
-              <div className="text-[#6b7280] mb-2">{t('debates.noDebates')}</div>
+              <div className="text-[#8b949e] mb-2">{t('debates.noDebates')}</div>
               <div className="text-xs text-[#3b3b3b]">
                 {t('debates.noDebatesDesc')}
               </div>
@@ -261,7 +262,7 @@ export default function DebatesPage() {
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: idx * 0.02 }}
-                  onClick={() => handleDebateClick(debate)}
+                  {...clickableProps(() => handleDebateClick(debate), debate.topic)}
                   className={`card-cli p-4 cursor-pointer transition-colors relative ${
                     isLive(debate)
                       ? 'border-[#ff6b35] bg-[#ff6b35]/5'
@@ -287,7 +288,7 @@ export default function DebatesPage() {
                       <div className={`text-xl font-bold ${isLive(debate) ? 'text-[#ff6b35] animate-pulse' : 'text-[#ff6b35]'}`}>
                         R{debate.round_number}
                       </div>
-                      <div className="text-[10px] text-[#6b7280]">
+                      <div className="text-[10px] text-[#8b949e]">
                         of {debate.max_rounds}
                       </div>
                     </div>
@@ -309,7 +310,7 @@ export default function DebatesPage() {
                           {debate.topic}
                         </div>
                       ) : (
-                        <div className="text-sm text-[#6b7280]">
+                        <div className="text-sm text-[#8b949e]">
                           Session #{debate.id.slice(0, 8)}
                         </div>
                       )}
@@ -321,7 +322,7 @@ export default function DebatesPage() {
                           </span>
                         ))}
                         {debate.participants.length > 4 && (
-                          <span className="text-[10px] text-[#6b7280]">
+                          <span className="text-[10px] text-[#8b949e]">
                             +{debate.participants.length - 4} more
                           </span>
                         )}
@@ -333,7 +334,7 @@ export default function DebatesPage() {
                       <div className={`text-lg font-bold ${isLive(debate) ? 'text-[#ff6b35]' : 'text-[#00ffff]'}`}>
                         {debate.message_count || 0}
                       </div>
-                      <div className="text-[10px] text-[#6b7280]">messages</div>
+                      <div className="text-[10px] text-[#8b949e]">messages</div>
                       {isLive(debate) && debate.total_cost > 0 && (
                         <div className="text-[10px] text-[#39ff14] mt-1">
                           ${debate.total_cost.toFixed(4)}
@@ -357,7 +358,7 @@ export default function DebatesPage() {
                   {/* Outcome preview for completed debates */}
                   {!isLive(debate) && debate.outcome && (
                     <div className="mt-3 pt-3 border-t border-[#21262d]">
-                      <div className="text-xs text-[#6b7280] line-clamp-1">
+                      <div className="text-xs text-[#8b949e] line-clamp-1">
                         <span className="text-[#39ff14]">Outcome:</span> {debate.outcome}
                       </div>
                     </div>

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -12,7 +12,7 @@
   --accent-purple: #bd93f9;
   --accent-yellow: #f1fa8c;
   --accent-red: #ff5555;
-  --muted: #6b7280;
+  --muted: #8b949e;
   --card-bg: rgba(13, 17, 23, 0.8);
   --scanline-opacity: 0.03;
 }

--- a/website/src/app/ideas/page.tsx
+++ b/website/src/app/ideas/page.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/lib/i18n';
 import { ApiClient, type ApiTrend, type ApiIdea, type ApiPlan, type ApiProject } from '@/lib/api';
 import { formatLocalDateTime } from '@/lib/date';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 import { TerminalWindow, TerminalBadge } from '@/components/TerminalWindow';
 import { IdeaComparison } from '@/components/visualization/IdeaComparison';
 import { TrendHeatmap } from '@/components/visualization/TrendHeatmap';
@@ -225,13 +226,13 @@ export default function IdeasPage() {
           <h1 className="text-2xl font-bold text-[#39ff14] mb-2">
             {t('ideas.pageTitle')}
           </h1>
-          <p className="text-sm text-[#6b7280]">
+          <p className="text-sm text-[#8b949e]">
             {t('ideas.pageSubtitle')}
           </p>
         </motion.div>
 
         {/* Tabs */}
-        <div className="flex gap-2 mb-6 border-b border-[#21262d] pb-4">
+        <div className="flex flex-wrap md:flex-nowrap gap-2 mb-6 border-b border-[#21262d] pb-4">
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -240,7 +241,7 @@ export default function IdeasPage() {
                 flex items-center gap-2 px-4 py-2 text-sm transition-colors rounded
                 ${viewMode === tab.id
                   ? 'bg-[#39ff14]/10 text-[#39ff14] border border-[#39ff14]/30'
-                  : 'text-[#6b7280] hover:bg-[#21262d] hover:text-[#c0c0c0]'
+                  : 'text-[#8b949e] hover:bg-[#21262d] hover:text-[#c0c0c0]'
                 }
               `}
             >
@@ -315,7 +316,7 @@ export default function IdeasPage() {
                             {item.count}
                           </div>
                           <div className="text-sm text-[#c0c0c0]">{t(item.stageKey)}</div>
-                          <div className="text-[10px] text-[#6b7280] mt-1">{t(item.descKey)}</div>
+                          <div className="text-[10px] text-[#8b949e] mt-1">{t(item.descKey)}</div>
                         </div>
                         {idx < 3 && (
                           <span className="text-[#21262d] mx-2 hidden md:block text-xl">→</span>
@@ -333,14 +334,14 @@ export default function IdeasPage() {
                       {trends.slice(0, 5).map((trend) => (
                         <div
                           key={trend.id}
-                          onClick={() => openModal('trend', { ...trend, title: getLocalizedText(trend.name, trend.name_ko) })}
+                          {...clickableProps(() => openModal('trend', { ...trend, title: getLocalizedText(trend.name, trend.name_ko) }), getLocalizedText(trend.name, trend.name_ko))}
                           className="p-3 rounded bg-black/20 border border-[#21262d] hover:border-[#bd93f9] cursor-pointer transition-colors"
                         >
                           <div className="flex items-center justify-between">
                             <span className="text-sm text-[#c0c0c0] truncate">{getLocalizedText(trend.name, trend.name_ko)}</span>
                             <span className="text-xs text-[#bd93f9]">{trend.score.toFixed(1)}</span>
                           </div>
-                          <div className="text-[10px] text-[#6b7280] mt-1">
+                          <div className="text-[10px] text-[#8b949e] mt-1">
                             {trend.signal_count} signals
                             {trend.analyzed_at && (
                               <span className="ml-2">
@@ -351,7 +352,7 @@ export default function IdeasPage() {
                         </div>
                       ))}
                       {trends.length === 0 && (
-                        <div className="text-center py-4 text-[#6b7280] text-sm">{t('ideas.noTrends')}</div>
+                        <div className="text-center py-4 text-[#8b949e] text-sm">{t('ideas.noTrends')}</div>
                       )}
                     </div>
                   </TerminalWindow>
@@ -362,16 +363,16 @@ export default function IdeasPage() {
                       {ideas.slice(0, 5).map((idea) => (
                         <div
                           key={idea.id}
-                          onClick={() => openModal('idea', { ...idea, title: getLocalizedText(idea.title, idea.title_ko) })}
+                          {...clickableProps(() => openModal('idea', { ...idea, title: getLocalizedText(idea.title, idea.title_ko) }), getLocalizedText(idea.title, idea.title_ko))}
                           className="p-3 rounded bg-black/20 border border-[#21262d] hover:border-[#39ff14] cursor-pointer transition-colors"
                         >
                           <div className="flex items-center justify-between">
                             <span className="text-sm text-[#c0c0c0] truncate flex-1">{getLocalizedText(idea.title, idea.title_ko)}</span>
-                            <span className={`text-xs ml-2 ${statusColors[idea.status] || 'text-[#6b7280]'}`}>
+                            <span className={`text-xs ml-2 ${statusColors[idea.status] || 'text-[#8b949e]'}`}>
                               {idea.status}
                             </span>
                           </div>
-                          <div className="text-[10px] text-[#6b7280] mt-1">
+                          <div className="text-[10px] text-[#8b949e] mt-1">
                             {idea.source_type} | Score: {idea.score.toFixed(1)}
                             {idea.created_at && (
                               <span className="ml-2">
@@ -382,7 +383,7 @@ export default function IdeasPage() {
                         </div>
                       ))}
                       {ideas.length === 0 && (
-                        <div className="text-center py-4 text-[#6b7280] text-sm">{t('ideas.noIdeas')}</div>
+                        <div className="text-center py-4 text-[#8b949e] text-sm">{t('ideas.noIdeas')}</div>
                       )}
                     </div>
                   </TerminalWindow>
@@ -413,7 +414,7 @@ export default function IdeasPage() {
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: idx * 0.02 }}
-                      onClick={() => openModal('trend', { ...trend, title: getLocalizedText(trend.name, trend.name_ko) })}
+                      {...clickableProps(() => openModal('trend', { ...trend, title: getLocalizedText(trend.name, trend.name_ko) }), getLocalizedText(trend.name, trend.name_ko))}
                       className="p-4 rounded border border-[#21262d] hover:border-[#bd93f9] cursor-pointer transition-colors bg-black/20"
                     >
                       <div className="flex items-start gap-4">
@@ -423,7 +424,7 @@ export default function IdeasPage() {
                         <div className="flex-1 min-w-0">
                           <h3 className="text-sm font-medium text-[#c0c0c0]">{getLocalizedText(trend.name, trend.name_ko)}</h3>
                           {(trend.description || trend.description_ko) && (
-                            <p className="text-xs text-[#6b7280] mt-1 line-clamp-2">{getLocalizedText(trend.description, trend.description_ko)}</p>
+                            <p className="text-xs text-[#8b949e] mt-1 line-clamp-2">{getLocalizedText(trend.description, trend.description_ko)}</p>
                           )}
                           <div className="flex flex-wrap gap-1 mt-2">
                             {trend.keywords?.slice(0, 3).map(kw => (
@@ -433,9 +434,9 @@ export default function IdeasPage() {
                         </div>
                         <div className="text-right">
                           <div className="text-sm font-bold text-[#00ffff]">{trend.signal_count}</div>
-                          <div className="text-[10px] text-[#6b7280]">signals</div>
+                          <div className="text-[10px] text-[#8b949e]">signals</div>
                           {trend.analyzed_at && (
-                            <div className="text-[10px] text-[#6b7280] mt-1">
+                            <div className="text-[10px] text-[#8b949e] mt-1">
                               {formatLocalDateTime(trend.analyzed_at, locale)}
                             </div>
                           )}
@@ -444,7 +445,7 @@ export default function IdeasPage() {
                     </motion.div>
                   ))}
                     {trends.length === 0 && (
-                      <div className="text-center py-12 text-[#6b7280]">{t('ideas.noTrends')}</div>
+                      <div className="text-center py-12 text-[#8b949e]">{t('ideas.noTrends')}</div>
                     )}
                   </div>
                 </TerminalWindow>
@@ -490,11 +491,11 @@ export default function IdeasPage() {
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: idx * 0.02 }}
-                      onClick={() => openModal('idea', { ...idea, title: getLocalizedText(idea.title, idea.title_ko) })}
+                      {...clickableProps(() => openModal('idea', { ...idea, title: getLocalizedText(idea.title, idea.title_ko) }), getLocalizedText(idea.title, idea.title_ko))}
                       className="p-4 rounded border border-[#21262d] hover:border-[#39ff14] cursor-pointer transition-colors bg-black/20"
                     >
                       <div className="flex items-start gap-4">
-                        <div className={`text-xl font-bold w-12 text-center ${statusColors[idea.status] || 'text-[#6b7280]'}`}>
+                        <div className={`text-xl font-bold w-12 text-center ${statusColors[idea.status] || 'text-[#8b949e]'}`}>
                           {idea.score.toFixed(1)}
                         </div>
                         <div className="flex-1 min-w-0">
@@ -503,9 +504,9 @@ export default function IdeasPage() {
                             <TerminalBadge variant="cyan">{idea.source_type}</TerminalBadge>
                           </div>
                           <h3 className="text-sm font-medium text-[#c0c0c0]">{getLocalizedText(idea.title, idea.title_ko)}</h3>
-                          <p className="text-xs text-[#6b7280] mt-1 line-clamp-2">{getIdeaSummaryText(getLocalizedText(idea.summary, idea.summary_ko))}</p>
+                          <p className="text-xs text-[#8b949e] mt-1 line-clamp-2">{getIdeaSummaryText(getLocalizedText(idea.summary, idea.summary_ko))}</p>
                           {idea.created_at && (
-                            <div className="text-[10px] text-[#6b7280] mt-2">
+                            <div className="text-[10px] text-[#8b949e] mt-2">
                               {formatLocalDateTime(idea.created_at, locale)}
                             </div>
                           )}
@@ -525,7 +526,7 @@ export default function IdeasPage() {
                     </motion.div>
                   ))}
                     {ideas.length === 0 && (
-                      <div className="text-center py-12 text-[#6b7280]">{t('ideas.noIdeas')}</div>
+                      <div className="text-center py-12 text-[#8b949e]">{t('ideas.noIdeas')}</div>
                     )}
                   </div>
                 </TerminalWindow>
@@ -542,7 +543,7 @@ export default function IdeasPage() {
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: idx * 0.02 }}
-                      onClick={() => openModal('plan', { ...plan, title: getLocalizedText(plan.title, plan.title_ko) })}
+                      {...clickableProps(() => openModal('plan', { ...plan, title: getLocalizedText(plan.title, plan.title_ko) }), getLocalizedText(plan.title, plan.title_ko))}
                       className="p-4 rounded border border-[#21262d] hover:border-[#ff6b35] cursor-pointer transition-colors bg-black/20"
                     >
                       <div className="flex items-center gap-4">
@@ -557,7 +558,7 @@ export default function IdeasPage() {
                           </div>
                           <h3 className="text-sm font-medium text-[#c0c0c0]">{getLocalizedText(plan.title, plan.title_ko)}</h3>
                           {plan.created_at && (
-                            <div className="text-[10px] text-[#6b7280] mt-1">
+                            <div className="text-[10px] text-[#8b949e] mt-1">
                               {formatLocalDateTime(plan.created_at, locale)}
                             </div>
                           )}
@@ -577,7 +578,7 @@ export default function IdeasPage() {
                     </motion.div>
                   ))}
                   {plans.length === 0 && (
-                    <div className="text-center py-12 text-[#6b7280]">{t('ideas.noPlans')}</div>
+                    <div className="text-center py-12 text-[#8b949e]">{t('ideas.noPlans')}</div>
                   )}
                 </div>
               </TerminalWindow>
@@ -602,7 +603,7 @@ export default function IdeasPage() {
                         initial={{ opacity: 0, x: -20 }}
                         animate={{ opacity: 1, x: 0 }}
                         transition={{ delay: idx * 0.02 }}
-                        onClick={() => openModal('project', { id: project.id, title: project.name })}
+                        {...clickableProps(() => openModal('project', { id: project.id, title: project.name }), project.name)}
                         className="p-4 rounded border border-[#21262d] hover:border-[#39ff14] cursor-pointer transition-colors bg-black/20"
                       >
                         <div className="flex items-start gap-4">
@@ -610,7 +611,7 @@ export default function IdeasPage() {
                             <div className={`text-xl font-bold ${project.status === 'ready' ? 'text-[#39ff14]' : project.status === 'generating' ? 'text-[#00ffff]' : 'text-[#ff5555]'}`}>
                               {project.files_generated > 0 ? project.files_generated : '-'}
                             </div>
-                            <div className="text-[10px] text-[#6b7280]">
+                            <div className="text-[10px] text-[#8b949e]">
                               {project.files_generated > 0 ? (locale === 'ko' ? '파일' : 'files') : ''}
                             </div>
                           </div>
@@ -631,12 +632,12 @@ export default function IdeasPage() {
                             </div>
                             <h3 className="text-sm font-medium text-[#c0c0c0]">{project.name}</h3>
                             {project.directory_path && (
-                              <div className="text-[10px] text-[#6b7280] mt-1 font-mono truncate">
+                              <div className="text-[10px] text-[#8b949e] mt-1 font-mono truncate">
                                 <span className="text-[#00ffff]">→</span> {project.directory_path}
                               </div>
                             )}
                             {project.created_at && (
-                              <div className="text-[10px] text-[#6b7280] mt-1">
+                              <div className="text-[10px] text-[#8b949e] mt-1">
                                 {formatLocalDateTime(project.created_at, locale)}
                               </div>
                             )}
@@ -647,7 +648,7 @@ export default function IdeasPage() {
                     );
                   })}
                   {projects.length === 0 && (
-                    <div className="text-center py-12 text-[#6b7280]">{t('ideas.noProjects')}</div>
+                    <div className="text-center py-12 text-[#8b949e]">{t('ideas.noProjects')}</div>
                   )}
                 </div>
               </TerminalWindow>

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { JetBrains_Mono } from "next/font/google";
+import { MotionConfig } from "framer-motion";
 import { I18nProvider } from "@/lib/i18n";
 import { ModalProvider } from "@/components/modals/ModalProvider";
 import { Navigation } from "@/components/Navigation";
@@ -49,25 +50,27 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko" className="dark">
+    <html lang="en" className="dark">
       <head>
         <meta name="theme-color" content="#0a0a0a" />
         <meta name="color-scheme" content="dark" />
       </head>
       <body className={`${jetbrainsMono.variable} font-mono antialiased`}>
         <I18nProvider>
-          <ModalProvider>
-            <div className="relative min-h-screen bg-[#0a0a0a]">
-              <Navigation />
-              <main className="relative z-10">
-                {children}
-              </main>
-              {/* NPC city cross-link — read-side fetch with 10-min
-                  revalidate; renders nothing if npc.moss.land is down. */}
-              <NpcCityStrip />
-              <Footer />
-            </div>
-          </ModalProvider>
+          <MotionConfig reducedMotion="user">
+            <ModalProvider>
+              <div className="relative min-h-screen bg-[#0a0a0a]">
+                <Navigation />
+                <main className="relative z-10">
+                  {children}
+                </main>
+                {/* NPC city cross-link — read-side fetch with 10-min
+                    revalidate; renders nothing if npc.moss.land is down. */}
+                <NpcCityStrip />
+                <Footer />
+              </div>
+            </ModalProvider>
+          </MotionConfig>
         </I18nProvider>
       </body>
     </html>

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -11,6 +11,7 @@ import { ActivityFeed } from '@/components/ActivityFeed';
 import { TerminalWindow, TerminalBadge } from '@/components/TerminalWindow';
 import { AdapterDetailModal } from '@/components/AdapterDetailModal';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 import { rssCategories, aiProviders, mockStats, mockPipeline } from '@/data/mock';
 import { fetchSystemStats, fetchActivity, fetchPipeline, fetchAdapters, ApiClient, type ApiProject } from '@/lib/api';
 import { formatLocalDateTime } from '@/lib/date';
@@ -97,7 +98,7 @@ export default function Dashboard() {
             {ASCII_LOGO}
           </pre>
           <div className="text-center mt-2">
-            <span className="text-[#6b7280] text-xs">
+            <span className="text-[#8b949e] text-xs">
               Multi-Agent AI Orchestration System v{APP_VERSION}
             </span>
           </div>
@@ -155,7 +156,10 @@ export default function Dashboard() {
                   return (
                     <motion.div
                       key={project.id}
-                      onClick={() => openModal('project', { id: project.id, title: project.name })}
+                      {...clickableProps(
+                        () => openModal('project', { id: project.id, title: project.name }),
+                        project.name
+                      )}
                       className="p-3 rounded border border-[#21262d] hover:border-[#39ff14] cursor-pointer transition-colors bg-black/20"
                       whileHover={{ scale: 1.02 }}
                     >
@@ -190,7 +194,7 @@ export default function Dashboard() {
                         )}
                       </div>
                       {project.created_at && (
-                        <div className="text-[10px] text-[#6b7280] mt-2">
+                        <div className="text-[10px] text-[#8b949e] mt-2">
                           {formatLocalDateTime(project.created_at, locale)}
                         </div>
                       )}
@@ -239,7 +243,7 @@ export default function Dashboard() {
                   className="w-full text-left hover:bg-[#21262d]/30 -m-3 p-3 rounded transition-colors"
                 >
                   <div className="space-y-2">
-                    <div className="text-[#6b7280] text-xs mb-3 flex justify-between items-center">
+                    <div className="text-[#8b949e] text-xs mb-3 flex justify-between items-center">
                       <span>
                         <span className="text-[#bd93f9]"># </span>
                         Signal adapters configuration
@@ -260,7 +264,7 @@ export default function Dashboard() {
                     ))}
                     <div className="border-t border-[#21262d] pt-3 mt-3">
                       <div className="flex justify-between items-center">
-                        <span className="text-[#6b7280] text-xs">total_adapters:</span>
+                        <span className="text-[#8b949e] text-xs">total_adapters:</span>
                         <span className="text-[#39ff14] font-bold">9</span>
                       </div>
                     </div>
@@ -277,7 +281,7 @@ export default function Dashboard() {
             >
               <TerminalWindow title="llm.status">
                 <div className="space-y-2">
-                  <div className="text-[#6b7280] text-xs mb-3">
+                  <div className="text-[#8b949e] text-xs mb-3">
                     <span className="text-[#bd93f9]"># </span>
                     LLM provider status (hybrid routing)
                   </div>
@@ -324,11 +328,11 @@ export default function Dashboard() {
 
                   <div className="border-t border-[#21262d] pt-3 mt-3">
                     <div className="flex justify-between items-center text-xs">
-                      <span className="text-[#6b7280]">daily_budget:</span>
+                      <span className="text-[#8b949e]">daily_budget:</span>
                       <span className="text-[#f1fa8c]">$50.00</span>
                     </div>
                     <div className="flex justify-between items-center text-xs">
-                      <span className="text-[#6b7280]">used_today:</span>
+                      <span className="text-[#8b949e]">used_today:</span>
                       <span className="text-[#39ff14]">$12.45</span>
                     </div>
                   </div>
@@ -349,7 +353,7 @@ export default function Dashboard() {
             href="https://github.com/MosslandOpenDevs/agentic-orchestrator"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 text-xs text-[#6b7280] hover:text-[#39ff14] transition-colors"
+            className="inline-flex items-center gap-2 text-xs text-[#8b949e] hover:text-[#39ff14] transition-colors"
           >
             <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>

--- a/website/src/app/projects/page.tsx
+++ b/website/src/app/projects/page.tsx
@@ -71,7 +71,7 @@ export default function ProjectsPage() {
           <h1 className="text-2xl font-bold text-[#39ff14] mb-2">
             {locale === 'ko' ? '프로젝트' : 'Projects'}
           </h1>
-          <p className="text-[#6b7280] text-sm">
+          <p className="text-[#8b949e] text-sm">
             {locale === 'ko'
               ? 'Plan에서 자동 생성된 프로젝트 스캐폴드'
               : 'Auto-generated project scaffolds from approved Plans'}
@@ -89,11 +89,11 @@ export default function ProjectsPage() {
               onClick={() => setStatusFilter(status)}
               className={`
                 card-cli p-4 text-left transition-all
-                ${isActive ? 'border-[#39ff14] bg-[#39ff14]/5' : 'hover:border-[#6b7280]'}
+                ${isActive ? 'border-[#39ff14] bg-[#39ff14]/5' : 'hover:border-[#8b949e]'}
               `}
             >
               <div className="text-2xl font-bold text-[#c0c0c0]">{count}</div>
-              <div className="text-xs text-[#6b7280] uppercase">
+              <div className="text-xs text-[#8b949e] uppercase">
                 {status === 'all'
                   ? (locale === 'ko' ? '전체' : 'Total')
                   : status === 'ready'
@@ -123,13 +123,13 @@ export default function ProjectsPage() {
           </div>
         ) : filteredProjects.length === 0 ? (
           <div className="text-center py-12">
-            <div className="text-[#6b7280] text-4xl mb-4">📁</div>
-            <div className="text-[#6b7280]">
+            <div className="text-[#8b949e] text-4xl mb-4">📁</div>
+            <div className="text-[#8b949e]">
               {locale === 'ko'
                 ? '프로젝트가 없습니다'
                 : 'No projects yet'}
             </div>
-            <div className="text-[#6b7280] text-sm mt-2">
+            <div className="text-[#8b949e] text-sm mt-2">
               {locale === 'ko'
                 ? '승인된 Plan에서 프로젝트를 생성하세요'
                 : 'Generate projects from approved Plans'}
@@ -172,12 +172,12 @@ export default function ProjectsPage() {
                       {project.name}
                     </h3>
                     {project.directory_path && (
-                      <div className="text-xs text-[#6b7280] mt-1 font-mono truncate">
+                      <div className="text-xs text-[#8b949e] mt-1 font-mono truncate">
                         <span className="text-[#00ffff]">→</span> {project.directory_path}
                       </div>
                     )}
                   </div>
-                  <div className="text-right text-xs text-[#6b7280] whitespace-nowrap">
+                  <div className="text-right text-xs text-[#8b949e] whitespace-nowrap">
                     <div>
                       {project.files_generated > 0 && (
                         <span className="text-[#39ff14]">{project.files_generated} files</span>
@@ -196,27 +196,27 @@ export default function ProjectsPage() {
 
       {/* Info Section */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-3">
+        <div className="text-xs text-[#8b949e] uppercase mb-3">
           {locale === 'ko' ? '프로젝트 생성 파이프라인' : 'Project Generation Pipeline'}
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs">
           <span className="text-[#c0c0c0]">Plan</span>
-          <span className="text-[#6b7280]">→</span>
+          <span className="text-[#8b949e]">→</span>
           <span className="text-[#00ffff]">{locale === 'ko' ? '마크다운 파싱' : 'Parse Markdown'}</span>
-          <span className="text-[#6b7280]">→</span>
+          <span className="text-[#8b949e]">→</span>
           <span className="text-[#bd93f9]">{locale === 'ko' ? '스택 감지' : 'Detect Stack'}</span>
-          <span className="text-[#6b7280]">→</span>
+          <span className="text-[#8b949e]">→</span>
           <span className="text-[#ff6b35]">{locale === 'ko' ? 'LLM 코드 생성' : 'LLM Code Gen'}</span>
-          <span className="text-[#6b7280]">→</span>
+          <span className="text-[#8b949e]">→</span>
           <span className="text-[#39ff14]">{locale === 'ko' ? '프로젝트' : 'Project'}</span>
         </div>
         <div className="mt-3 grid grid-cols-2 md:grid-cols-2 gap-2 text-xs">
           <div className="p-2 border border-[#21262d] rounded">
-            <div className="text-[#6b7280]">{locale === 'ko' ? '채팅 / 생성' : 'Chat / Gen'}</div>
+            <div className="text-[#8b949e]">{locale === 'ko' ? '채팅 / 생성' : 'Chat / Gen'}</div>
             <div className="text-[#bd93f9] font-mono">qwen3.5:9b</div>
           </div>
           <div className="p-2 border border-[#21262d] rounded">
-            <div className="text-[#6b7280]">{locale === 'ko' ? '임베딩' : 'Embedding'}</div>
+            <div className="text-[#8b949e]">{locale === 'ko' ? '임베딩' : 'Embedding'}</div>
             <div className="text-[#00ffff] font-mono">qwen3-embedding:0.6b</div>
           </div>
         </div>

--- a/website/src/app/system/page.tsx
+++ b/website/src/app/system/page.tsx
@@ -110,13 +110,13 @@ export default function SystemPage() {
           <h1 className="text-2xl font-bold text-[#00ffff] mb-2">
             {t('system.pageTitle')}
           </h1>
-          <p className="text-sm text-[#6b7280]">
+          <p className="text-sm text-[#8b949e]">
             {t('system.pageSubtitle')}
           </p>
         </motion.div>
 
         {/* Tabs */}
-        <div className="flex gap-2 mb-6 border-b border-[#21262d] pb-4">
+        <div className="flex flex-wrap md:flex-nowrap gap-2 mb-6 border-b border-[#21262d] pb-4">
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -125,7 +125,7 @@ export default function SystemPage() {
                 flex items-center gap-2 px-4 py-2 text-sm transition-colors rounded
                 ${viewMode === tab.id
                   ? 'bg-[#00ffff]/10 text-[#00ffff] border border-[#00ffff]/30'
-                  : 'text-[#6b7280] hover:bg-[#21262d] hover:text-[#c0c0c0]'
+                  : 'text-[#8b949e] hover:bg-[#21262d] hover:text-[#c0c0c0]'
                 }
               `}
             >
@@ -189,7 +189,7 @@ export default function SystemPage() {
                       `}>
                         {stat.value}
                       </div>
-                      <div className="text-xs text-[#6b7280] mt-1">{stat.label}</div>
+                      <div className="text-xs text-[#8b949e] mt-1">{stat.label}</div>
                     </div>
                   ))}
                 </div>
@@ -205,7 +205,7 @@ export default function SystemPage() {
                     className={`text-xs px-3 py-1 rounded transition-colors ${
                       timelinePeriod === '24h'
                         ? 'bg-[#39ff14]/20 text-[#39ff14] border border-[#39ff14]/30'
-                        : 'text-[#6b7280] hover:bg-[#21262d]'
+                        : 'text-[#8b949e] hover:bg-[#21262d]'
                     }`}
                   >
                     Last 24h
@@ -215,7 +215,7 @@ export default function SystemPage() {
                     className={`text-xs px-3 py-1 rounded transition-colors ${
                       timelinePeriod === '7d'
                         ? 'bg-[#39ff14]/20 text-[#39ff14] border border-[#39ff14]/30'
-                        : 'text-[#6b7280] hover:bg-[#21262d]'
+                        : 'text-[#8b949e] hover:bg-[#21262d]'
                     }`}
                   >
                     Last 7 days
@@ -230,7 +230,7 @@ export default function SystemPage() {
                   showDetails={true}
                 />
               ) : (
-                <div className="text-center py-8 text-[#6b7280]">
+                <div className="text-center py-8 text-[#8b949e]">
                   Loading timeline data...
                 </div>
               )}
@@ -267,7 +267,7 @@ export default function SystemPage() {
                         `} />
                         <span className="text-xs text-[#c0c0c0]">{stage.name}</span>
                       </div>
-                      <div className="text-[10px] text-[#6b7280] mt-1">{stage.desc}</div>
+                      <div className="text-[10px] text-[#8b949e] mt-1">{stage.desc}</div>
                     </div>
                     {idx < 5 && <span className="text-[#21262d]">→</span>}
                   </div>
@@ -291,7 +291,7 @@ export default function SystemPage() {
             <TerminalWindow title="FILTERS" className="mb-6">
               <div className="flex flex-wrap gap-4">
                 <div>
-                  <label className="text-xs text-[#6b7280] block mb-1">{t('system.filter.source')}</label>
+                  <label className="text-xs text-[#8b949e] block mb-1">{t('system.filter.source')}</label>
                   <select
                     value={signalFilter.source || ''}
                     onChange={(e) => setSignalFilter({ ...signalFilter, source: e.target.value || undefined })}
@@ -304,7 +304,7 @@ export default function SystemPage() {
                   </select>
                 </div>
                 <div>
-                  <label className="text-xs text-[#6b7280] block mb-1">{t('system.filter.category')}</label>
+                  <label className="text-xs text-[#8b949e] block mb-1">{t('system.filter.category')}</label>
                   <select
                     value={signalFilter.category || ''}
                     onChange={(e) => setSignalFilter({ ...signalFilter, category: e.target.value || undefined })}
@@ -322,7 +322,7 @@ export default function SystemPage() {
             {/* Signals List */}
             <TerminalWindow title={`RAW_SIGNALS (${signals.length})`}>
               {signals.length === 0 ? (
-                <div className="text-center py-12 text-[#6b7280]">
+                <div className="text-center py-12 text-[#8b949e]">
                   {t('system.noSignals')}
                 </div>
               ) : (
@@ -392,7 +392,7 @@ export default function SystemPage() {
                 href="https://github.com/MosslandOpenDevs/agentic-orchestrator"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2 rounded border border-[#21262d] text-sm text-[#6b7280] hover:text-[#39ff14] hover:border-[#39ff14] transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded border border-[#21262d] text-sm text-[#8b949e] hover:text-[#39ff14] hover:border-[#39ff14] transition-colors"
               >
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>

--- a/website/src/app/transparency/debates/page.tsx
+++ b/website/src/app/transparency/debates/page.tsx
@@ -64,7 +64,7 @@ export default function DebatesPage() {
           <h1 className="text-2xl font-bold text-[#ff6b35] mb-2">
             💬 {t('debates.title')}
           </h1>
-          <p className="text-sm text-[#6b7280]">
+          <p className="text-sm text-[#8b949e]">
             {t('debates.subtitle')}
           </p>
         </motion.div>
@@ -86,13 +86,13 @@ export default function DebatesPage() {
                 <div className={`text-xs font-bold ${['text-[#39ff14]', 'text-[#00ffff]', 'text-[#ff6b35]', 'text-[#bd93f9]'][idx]}`}>
                   {role}
                 </div>
-                <div className="text-[10px] text-[#6b7280] mt-1">
+                <div className="text-[10px] text-[#8b949e] mt-1">
                   {t(`role.${role.toLowerCase().replace(' ', '')}.perspective`)}
                 </div>
               </motion.div>
             ))}
           </div>
-          <div className="text-center text-xs text-[#6b7280] mt-4">
+          <div className="text-center text-xs text-[#8b949e] mt-4">
             {t('debates.rotationInfo')}
           </div>
         </TerminalWindow>
@@ -102,7 +102,7 @@ export default function DebatesPage() {
           <div className="flex flex-wrap gap-4">
             {/* Status Filter */}
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('debates.status')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('debates.status')}</label>
               <select
                 value={filter.status || ''}
                 onChange={(e) => setFilter({ ...filter, status: e.target.value || undefined })}
@@ -117,7 +117,7 @@ export default function DebatesPage() {
 
             {/* Phase Filter */}
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('debates.phase')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('debates.phase')}</label>
               <select
                 value={filter.phase || ''}
                 onChange={(e) => setFilter({ ...filter, phase: e.target.value || undefined })}
@@ -142,7 +142,7 @@ export default function DebatesPage() {
               </div>
             </div>
           ) : debates.length === 0 ? (
-            <div className="text-center py-12 text-[#6b7280]">
+            <div className="text-center py-12 text-[#8b949e]">
               {t('debates.noDebates')}
             </div>
           ) : (
@@ -162,7 +162,7 @@ export default function DebatesPage() {
                       <div className="text-xl font-bold text-[#ff6b35]">
                         R{debate.round_number}
                       </div>
-                      <div className="text-[10px] text-[#6b7280]">
+                      <div className="text-[10px] text-[#8b949e]">
                         /{debate.max_rounds}
                       </div>
                     </div>
@@ -194,7 +194,7 @@ export default function DebatesPage() {
                       <div className="text-lg font-bold text-[#00ffff]">
                         {debate.message_count || 0}
                       </div>
-                      <div className="text-[10px] text-[#6b7280]">{t('debates.messages')}</div>
+                      <div className="text-[10px] text-[#8b949e]">{t('debates.messages')}</div>
                     </div>
 
                     {/* Arrow */}
@@ -204,7 +204,7 @@ export default function DebatesPage() {
                   {/* Outcome preview */}
                   {debate.outcome && (
                     <div className="mt-3 pt-3 border-t border-[#21262d]">
-                      <div className="text-xs text-[#6b7280] line-clamp-1">
+                      <div className="text-xs text-[#8b949e] line-clamp-1">
                         <span className="text-[#39ff14]">✓</span> {debate.outcome}
                       </div>
                     </div>

--- a/website/src/app/transparency/page.tsx
+++ b/website/src/app/transparency/page.tsx
@@ -136,7 +136,7 @@ export default function TransparencyPage() {
           <h1 className="text-2xl md:text-3xl font-bold text-[#39ff14] mb-2">
             {t('transparency.title')}
           </h1>
-          <p className="text-sm text-[#6b7280]">
+          <p className="text-sm text-[#8b949e]">
             {t('transparency.subtitle')}
           </p>
         </motion.div>
@@ -191,7 +191,7 @@ export default function TransparencyPage() {
                           <div className={`text-2xl font-bold ${colors.text}`}>
                             {loading ? '...' : section.stat}
                           </div>
-                          <div className="text-[10px] text-[#6b7280]">
+                          <div className="text-[10px] text-[#8b949e]">
                             {section.statLabel}
                           </div>
                         </div>
@@ -201,11 +201,11 @@ export default function TransparencyPage() {
                     <h3 className={`text-lg font-bold mb-2 ${colors.text}`}>
                       {section.title}
                     </h3>
-                    <p className="text-sm text-[#6b7280] leading-relaxed">
+                    <p className="text-sm text-[#8b949e] leading-relaxed">
                       {section.description}
                     </p>
 
-                    <div className="mt-4 flex items-center text-xs text-[#6b7280]">
+                    <div className="mt-4 flex items-center text-xs text-[#8b949e]">
                       <span>{t('transparency.viewDetails')}</span>
                       <span className="ml-2">→</span>
                     </div>
@@ -224,7 +224,7 @@ export default function TransparencyPage() {
           className="mt-8"
         >
           <TerminalWindow title="INFO">
-            <div className="text-xs text-[#6b7280] space-y-2">
+            <div className="text-xs text-[#8b949e] space-y-2">
               <p>
                 <span className="text-[#00ffff]">$</span> {t('transparency.info1')}
               </p>

--- a/website/src/app/transparency/signals/page.tsx
+++ b/website/src/app/transparency/signals/page.tsx
@@ -67,7 +67,7 @@ export default function SignalsPage() {
           <h1 className="text-2xl font-bold text-[#00ffff] mb-2">
             📡 {t('signals.title')}
           </h1>
-          <p className="text-sm text-[#6b7280]">
+          <p className="text-sm text-[#8b949e]">
             {t('signals.subtitle')}
           </p>
         </motion.div>
@@ -77,7 +77,7 @@ export default function SignalsPage() {
           <div className="flex flex-wrap gap-4">
             {/* Source Filter */}
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('signals.source')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('signals.source')}</label>
               <select
                 value={filter.source || ''}
                 onChange={(e) => setFilter({ ...filter, source: e.target.value || undefined })}
@@ -92,7 +92,7 @@ export default function SignalsPage() {
 
             {/* Category Filter */}
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('signals.category')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('signals.category')}</label>
               <select
                 value={filter.category || ''}
                 onChange={(e) => setFilter({ ...filter, category: e.target.value || undefined })}
@@ -107,7 +107,7 @@ export default function SignalsPage() {
 
             {/* Min Score Filter */}
             <div>
-              <label className="text-xs text-[#6b7280] block mb-1">{t('signals.minScore')}</label>
+              <label className="text-xs text-[#8b949e] block mb-1">{t('signals.minScore')}</label>
               <select
                 value={filter.minScore || ''}
                 onChange={(e) => setFilter({ ...filter, minScore: e.target.value ? Number(e.target.value) : undefined })}
@@ -132,7 +132,7 @@ export default function SignalsPage() {
               </div>
             </div>
           ) : signals.length === 0 ? (
-            <div className="text-center py-12 text-[#6b7280]">
+            <div className="text-center py-12 text-[#8b949e]">
               {t('signals.noSignals')}
             </div>
           ) : (
@@ -169,7 +169,7 @@ export default function SignalsPage() {
                         {signal.title}
                       </h3>
                       {signal.summary && (
-                        <p className="text-xs text-[#6b7280] mt-1 line-clamp-2">
+                        <p className="text-xs text-[#8b949e] mt-1 line-clamp-2">
                           {signal.summary}
                         </p>
                       )}

--- a/website/src/components/ActivityFeed.tsx
+++ b/website/src/components/ActivityFeed.tsx
@@ -40,7 +40,7 @@ export function ActivityFeed({ activities, isLoading = false }: ActivityFeedProp
     plan: { color: 'text-[#bd93f9]', prefix: 'PLAN', icon: '◇' },
     debate: { color: 'text-[#ff6b35]', prefix: 'DEBATE', icon: '◉' },
     dev: { color: 'text-[#39ff14]', prefix: 'DEV', icon: '●' },
-    system: { color: 'text-[#6b7280]', prefix: 'SYS', icon: '○' },
+    system: { color: 'text-[#8b949e]', prefix: 'SYS', icon: '○' },
   };
 
   return (
@@ -49,7 +49,7 @@ export function ActivityFeed({ activities, isLoading = false }: ActivityFeedProp
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="text-[#bd93f9] text-xs">#</span>
-          <span className="text-[#6b7280] text-xs">Real-time activity stream</span>
+          <span className="text-[#8b949e] text-xs">Real-time activity stream</span>
         </div>
         <motion.div
           className="flex items-center gap-1.5"
@@ -85,7 +85,7 @@ export function ActivityFeed({ activities, isLoading = false }: ActivityFeedProp
                 className="flex items-start gap-2 py-1 hover:bg-[#21262d]/50 px-1 -mx-1 transition-colors"
               >
                 {/* Timestamp */}
-                <span className="text-[#6b7280] shrink-0 tabular-nums">
+                <span className="text-[#8b949e] shrink-0 tabular-nums">
                   [{activity.time}]
                 </span>
 
@@ -110,14 +110,14 @@ export function ActivityFeed({ activities, isLoading = false }: ActivityFeedProp
           animate={{ opacity: [0.3, 1, 0.3] }}
           transition={{ duration: 1, repeat: Infinity }}
         >
-          <span className="text-[#6b7280]">[--:--:--]</span>
+          <span className="text-[#8b949e]">[--:--:--]</span>
           <span>▋</span>
         </motion.div>
       </div>
 
       {/* Footer */}
       <div className="mt-3 pt-2 border-t border-[#21262d] flex items-center justify-between text-[10px]">
-        <span className="text-[#6b7280]">
+        <span className="text-[#8b949e]">
           {isLoading ? 'Loading events...' : `Showing last ${activities.length} events`}
         </span>
         <div className="flex items-center gap-3">

--- a/website/src/components/AdapterDetailModal.tsx
+++ b/website/src/components/AdapterDetailModal.tsx
@@ -93,7 +93,7 @@ export function AdapterDetailModal({
               </div>
               <button
                 onClick={onClose}
-                className="text-[#6b7280] hover:text-[#c0c0c0] transition-colors text-xl"
+                className="text-[#8b949e] hover:text-[#c0c0c0] transition-colors text-xl"
               >
                 ×
               </button>
@@ -104,7 +104,7 @@ export function AdapterDetailModal({
               {/* Adapter List */}
               <div className="w-1/3 border-r border-[#30363d] overflow-y-auto">
                 {isLoading ? (
-                  <div className="p-4 text-center text-[#6b7280]">
+                  <div className="p-4 text-center text-[#8b949e]">
                     <motion.span
                       animate={{ opacity: [0.3, 1, 0.3] }}
                       transition={{ duration: 1.5, repeat: Infinity }}
@@ -133,7 +133,7 @@ export function AdapterDetailModal({
                             <span className="status-dot offline ml-auto" style={{ width: 6, height: 6 }} />
                           )}
                         </div>
-                        <div className="text-[10px] text-[#6b7280] truncate">
+                        <div className="text-[10px] text-[#8b949e] truncate">
                           {locale === 'ko' ? adapter.description : adapter.description_en}
                         </div>
                         {adapter.source_count && (
@@ -158,7 +158,7 @@ export function AdapterDetailModal({
                         <h3 className={`text-lg font-mono ${categoryColors[selectedAdapter.category] || 'text-[#c0c0c0]'}`}>
                           {selectedAdapter.name}
                         </h3>
-                        <p className="text-xs text-[#6b7280]">
+                        <p className="text-xs text-[#8b949e]">
                           {locale === 'ko' ? selectedAdapter.description : selectedAdapter.description_en}
                         </p>
                       </div>
@@ -169,23 +169,23 @@ export function AdapterDetailModal({
                       <div className="text-[#bd93f9] text-xs mb-2"># Status</div>
                       <div className="grid grid-cols-2 gap-2 text-xs">
                         <div className="flex justify-between">
-                          <span className="text-[#6b7280]">enabled:</span>
+                          <span className="text-[#8b949e]">enabled:</span>
                           <span className={selectedAdapter.enabled ? 'text-[#39ff14]' : 'text-[#ff6b35]'}>
                             {selectedAdapter.enabled ? 'true' : 'false'}
                           </span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-[#6b7280]">category:</span>
+                          <span className="text-[#8b949e]">category:</span>
                           <span className={categoryColors[selectedAdapter.category]}>{selectedAdapter.category}</span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-[#6b7280]">last_fetch:</span>
+                          <span className="text-[#8b949e]">last_fetch:</span>
                           <span className="text-[#c0c0c0]">
                             {selectedAdapter.last_fetch || 'never'}
                           </span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-[#6b7280]">source_count:</span>
+                          <span className="text-[#8b949e]">source_count:</span>
                           <span className="text-[#f1fa8c]">{selectedAdapter.source_count || 0}</span>
                         </div>
                       </div>
@@ -198,7 +198,7 @@ export function AdapterDetailModal({
                         <div className="space-y-1 text-xs font-mono">
                           {Object.entries(selectedAdapter.health).map(([key, value]) => (
                             <div key={key} className="flex justify-between">
-                              <span className="text-[#6b7280]">{key}:</span>
+                              <span className="text-[#8b949e]">{key}:</span>
                               <span className={
                                 value === true || value === 'connected' || value === 'healthy'
                                   ? 'text-[#39ff14]'
@@ -242,7 +242,7 @@ export function AdapterDetailModal({
                     )}
                   </div>
                 ) : (
-                  <div className="h-full flex items-center justify-center text-[#6b7280] text-sm">
+                  <div className="h-full flex items-center justify-center text-[#8b949e] text-sm">
                     {locale === 'ko'
                       ? '왼쪽에서 어댑터를 선택하세요'
                       : 'Select an adapter from the list'
@@ -254,7 +254,7 @@ export function AdapterDetailModal({
 
             {/* Footer */}
             <div className="p-3 border-t border-[#30363d] flex justify-between items-center text-xs">
-              <div className="text-[#6b7280]">
+              <div className="text-[#8b949e]">
                 {adapters.filter(a => a.enabled).length} / {adapters.length} enabled
               </div>
               <div className="flex gap-2">

--- a/website/src/components/DetailPageLayout.tsx
+++ b/website/src/components/DetailPageLayout.tsx
@@ -34,7 +34,7 @@ export function DetailPageLayout({
         >
           <Link
             href={backUrl}
-            className="inline-flex items-center gap-2 text-sm text-[#6b7280] hover:text-[#00ffff] transition-colors"
+            className="inline-flex items-center gap-2 text-sm text-[#8b949e] hover:text-[#00ffff] transition-colors"
           >
             <span>←</span>
             <span>{backLabel}</span>

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -58,14 +58,14 @@ export function Footer() {
               <span className="text-[#39ff14] font-bold tracking-wider glow-green">
                 MOSS
               </span>
-              <span className="text-[#6b7280]">::</span>
+              <span className="text-[#8b949e]">::</span>
               <span className="text-[#00ffff]">AO</span>
             </div>
-            <p className="text-[10px] text-[#6b7280] leading-relaxed">
+            <p className="text-[10px] text-[#8b949e] leading-relaxed">
               Multi-agent AI orchestration system<br />
               for the Mossland ecosystem
             </p>
-            <div className="mt-3 text-[10px] text-[#6b7280]">
+            <div className="mt-3 text-[10px] text-[#8b949e]">
               <span className="text-[#bd93f9]"># </span>
               Building the Invisible Bridge
             </div>
@@ -74,7 +74,7 @@ export function Footer() {
           {/* Center - Links */}
           <div className="flex justify-center">
             <div className="space-y-2">
-              <div className="text-[10px] text-[#6b7280] uppercase tracking-wider mb-3">
+              <div className="text-[10px] text-[#8b949e] uppercase tracking-wider mb-3">
                 Quick Links
               </div>
               <a
@@ -106,7 +106,7 @@ export function Footer() {
 
           {/* Right - Social */}
           <div className="flex flex-col items-end">
-            <div className="text-[10px] text-[#6b7280] uppercase tracking-wider mb-3">
+            <div className="text-[10px] text-[#8b949e] uppercase tracking-wider mb-3">
               Connect
             </div>
             <div className="flex items-center gap-2">
@@ -116,7 +116,7 @@ export function Footer() {
                   href={link.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="p-2 border border-[#21262d] text-[#6b7280] hover:border-[#39ff14] hover:text-[#39ff14] transition-all"
+                  className="p-2 border border-[#21262d] text-[#8b949e] hover:border-[#39ff14] hover:text-[#39ff14] transition-all"
                   aria-label={link.name}
                 >
                   {link.icon}
@@ -128,10 +128,10 @@ export function Footer() {
 
         {/* Bottom bar */}
         <div className="mt-8 pt-4 border-t border-[#21262d] flex flex-wrap items-center justify-between gap-4">
-          <div className="text-[10px] text-[#6b7280]">
+          <div className="text-[10px] text-[#8b949e]">
             © 2025, 2026 MOSSLAND. ALL RIGHTS RESERVED.
           </div>
-          <div className="flex items-center gap-4 text-[10px] text-[#6b7280]">
+          <div className="flex items-center gap-4 text-[10px] text-[#8b949e]">
             <span>v{APP_VERSION}{APP_CODENAME ? ` "${APP_CODENAME}"` : ''}</span>
             <span className="text-[#21262d]">|</span>
             <span className="flex items-center gap-1">

--- a/website/src/components/IdeaContent.tsx
+++ b/website/src/components/IdeaContent.tsx
@@ -229,7 +229,7 @@ export function IdeaContent({ content, contentKo }: IdeaContentProps) {
               <div key={idx} className="bg-black/20 rounded p-2 flex items-center justify-between">
                 <div>
                   <div className="text-xs text-[#c0c0c0]">{kpi.metric}</div>
-                  <div className="text-[10px] text-[#6b7280]">{kpi.measurement}</div>
+                  <div className="text-[10px] text-[#8b949e]">{kpi.measurement}</div>
                 </div>
                 <div className="text-sm font-bold text-[#39ff14]">{kpi.target}</div>
               </div>

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -22,16 +22,16 @@ export function Navigation() {
   ];
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 border-b border-[#21262d] bg-[#0d1117]/95 backdrop-blur-md">
+    <nav aria-label="Main navigation" className="fixed top-0 left-0 right-0 z-50 border-b border-[#21262d] bg-[#0d1117]/95 backdrop-blur-md">
       <div className="mx-auto flex h-12 max-w-7xl items-center justify-between px-4">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2 group">
           <span className="text-[#39ff14] font-bold text-sm tracking-wider glow-green">
             MOSS
           </span>
-          <span className="text-[#6b7280]">::</span>
+          <span className="text-[#8b949e]">::</span>
           <span className="text-[#00ffff] text-sm">AO</span>
-          <span className="hidden sm:inline-block text-[#6b7280] text-xs ml-2">
+          <span className="hidden sm:inline-block text-[#8b949e] text-xs ml-2">
             v{APP_VERSION}
           </span>
         </Link>
@@ -48,11 +48,11 @@ export function Navigation() {
                   relative px-3 py-1.5 text-xs tracking-wide transition-all flex items-center gap-1.5
                   ${isActive
                     ? 'text-[#39ff14] bg-[#39ff14]/10 border border-[#39ff14]/30'
-                    : 'text-[#6b7280] hover:text-[#c0c0c0] hover:bg-[#21262d]'
+                    : 'text-[#8b949e] hover:text-[#c0c0c0] hover:bg-[#21262d]'
                   }
                 `}
               >
-                <span className="text-sm">{item.icon}</span>
+                <span className="text-sm" aria-hidden="true">{item.icon}</span>
                 {t(item.labelKey)}
                 {isActive && (
                   <motion.span
@@ -94,9 +94,12 @@ export function Navigation() {
           {/* Mobile menu button */}
           <button
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            className="md:hidden p-1 text-[#6b7280] hover:text-[#39ff14]"
+            aria-label={isMobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-menu"
+            className="md:hidden p-2 -mr-1 text-[#8b949e] hover:text-[#39ff14]"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               {isMobileMenuOpen ? (
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               ) : (
@@ -110,6 +113,7 @@ export function Navigation() {
       {/* Mobile Navigation */}
       {isMobileMenuOpen && (
         <motion.div
+          id="mobile-menu"
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -10 }}
@@ -127,11 +131,11 @@ export function Navigation() {
                     flex items-center gap-2 px-3 py-2 text-xs
                     ${isActive
                       ? 'text-[#39ff14] bg-[#39ff14]/10'
-                      : 'text-[#6b7280]'
+                      : 'text-[#8b949e]'
                     }
                   `}
                 >
-                  <span className="text-sm">{item.icon}</span>
+                  <span className="text-sm" aria-hidden="true">{item.icon}</span>
                   {t(item.labelKey)}
                 </Link>
               );

--- a/website/src/components/Pipeline.tsx
+++ b/website/src/components/Pipeline.tsx
@@ -52,7 +52,7 @@ export function Pipeline({ stages }: PipelineProps) {
       glow: 'shadow-[0_0_15px_rgba(57,255,20,0.3)]',
     },
     completed: {
-      border: 'border-[#6b7280]',
+      border: 'border-[#8b949e]',
       bg: 'bg-[#21262d]',
       text: 'text-[#c0c0c0]',
       glow: '',
@@ -60,7 +60,7 @@ export function Pipeline({ stages }: PipelineProps) {
     idle: {
       border: 'border-[#21262d]',
       bg: 'bg-[#0d1117]',
-      text: 'text-[#6b7280]',
+      text: 'text-[#8b949e]',
       glow: '',
     },
   };
@@ -166,7 +166,7 @@ export function Pipeline({ stages }: PipelineProps) {
                   </span>
 
                   {/* Stage name */}
-                  <span className="text-[10px] text-[#6b7280] mt-1 uppercase tracking-wider">
+                  <span className="text-[10px] text-[#8b949e] mt-1 uppercase tracking-wider">
                     {stage.name}
                   </span>
 
@@ -221,7 +221,7 @@ export function Pipeline({ stages }: PipelineProps) {
                     </div>
                     {/* Conversion rate label */}
                     {conversionRates && (
-                      <div className="absolute -bottom-4 left-1/2 -translate-x-1/2 text-[8px] text-[#6b7280] whitespace-nowrap">
+                      <div className="absolute -bottom-4 left-1/2 -translate-x-1/2 text-[8px] text-[#8b949e] whitespace-nowrap">
                         {index === 0 && `${conversionRates.signals_to_trends}%`}
                         {index === 1 && `${conversionRates.trends_to_ideas}%`}
                         {index === 2 && `${conversionRates.ideas_to_plans}%`}
@@ -239,7 +239,7 @@ export function Pipeline({ stages }: PipelineProps) {
       {/* Conversion rates summary */}
       {conversionRates && (
         <div className="mt-6 pt-3 border-t border-[#21262d]">
-          <div className="text-[10px] text-[#6b7280] text-center mb-2">
+          <div className="text-[10px] text-[#8b949e] text-center mb-2">
             {t('pipeline.conversionRates')}
           </div>
           <div className="flex justify-center items-center gap-2 text-xs text-[#c0c0c0]">
@@ -257,7 +257,7 @@ export function Pipeline({ stages }: PipelineProps) {
       {/* Currently processing */}
       {liveData?.processing && liveData.processing.length > 0 && (
         <div className="mt-4 pt-3 border-t border-[#21262d]">
-          <div className="text-[10px] text-[#6b7280] uppercase tracking-wider mb-2">
+          <div className="text-[10px] text-[#8b949e] uppercase tracking-wider mb-2">
             {t('pipeline.currentlyProcessing')}
           </div>
           <div className="space-y-1.5 max-h-24 overflow-y-auto">
@@ -280,7 +280,7 @@ export function Pipeline({ stages }: PipelineProps) {
                     [{item.type}]
                   </span>
                   <span className="text-[#c0c0c0] flex-1 truncate">{item.title}</span>
-                  <span className="text-[#6b7280] text-[10px]">({item.time_ago})</span>
+                  <span className="text-[#8b949e] text-[10px]">({item.time_ago})</span>
                 </motion.div>
               ))}
             </AnimatePresence>
@@ -292,15 +292,15 @@ export function Pipeline({ stages }: PipelineProps) {
       <div className="mt-4 pt-3 border-t border-[#21262d] flex flex-wrap justify-center gap-4 text-[10px]">
         <div className="flex items-center gap-2">
           <div className="w-2 h-2 bg-[#39ff14]" />
-          <span className="text-[#6b7280] uppercase tracking-wider">{t('pipeline.active')}</span>
+          <span className="text-[#8b949e] uppercase tracking-wider">{t('pipeline.active')}</span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-2 h-2 bg-[#6b7280]" />
-          <span className="text-[#6b7280] uppercase tracking-wider">{t('pipeline.completed')}</span>
+          <div className="w-2 h-2 bg-[#8b949e]" />
+          <span className="text-[#8b949e] uppercase tracking-wider">{t('pipeline.completed')}</span>
         </div>
         <div className="flex items-center gap-2">
           <div className="w-2 h-2 border border-[#21262d]" />
-          <span className="text-[#6b7280] uppercase tracking-wider">{t('pipeline.idle')}</span>
+          <span className="text-[#8b949e] uppercase tracking-wider">{t('pipeline.idle')}</span>
         </div>
       </div>
     </div>

--- a/website/src/components/Stats.tsx
+++ b/website/src/components/Stats.tsx
@@ -4,6 +4,7 @@ import { motion, useMotionValue, useTransform, animate } from 'framer-motion';
 import { useEffect } from 'react';
 import { useI18n } from '@/lib/i18n';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 
 interface StatCardProps {
   label: string;
@@ -54,23 +55,24 @@ function StatCard({ label, value, subValue, color = 'green', delay = 0, onClick 
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: delay * 0.1 }}
       whileHover={{ y: -2 }}
-      onClick={onClick}
+      {...(onClick ? clickableProps(onClick, label) : {})}
       className={`
-        card-cli p-4 border cursor-pointer
+        card-cli p-4 border
+        ${onClick ? 'cursor-pointer' : ''}
         ${colorClasses[color]}
         ${glowClasses[color]}
         transition-all duration-200
       `}
     >
       <div className="flex items-center justify-between mb-2">
-        <span className="text-[10px] text-[#6b7280] uppercase tracking-wider">{label}</span>
+        <span className="text-[10px] text-[#8b949e] uppercase tracking-wider">{label}</span>
       </div>
       <div className="flex items-baseline gap-2">
         <span className={`text-2xl font-bold ${colorClasses[color].split(' ')[0]}`}>
           <AnimatedNumber value={value} delay={delay * 0.1} />
         </span>
         {subValue && (
-          <span className="text-xs text-[#6b7280]">
+          <span className="text-xs text-[#8b949e]">
             (<span className="text-[#ff5555]">{subValue.value}</span> {subValue.label})
           </span>
         )}

--- a/website/src/components/SystemStatus.tsx
+++ b/website/src/components/SystemStatus.tsx
@@ -50,11 +50,11 @@ export function SystemStatus({ lastRun, nextRun }: SystemStatusProps) {
 
         {/* Last Run */}
         <div className="flex items-center gap-2">
-          <span className="text-[#6b7280] text-xs">last_run:</span>
+          <span className="text-[#8b949e] text-xs">last_run:</span>
           <span className="text-[#c0c0c0] text-xs">
             {formatDistanceToNow(lastRunDate, { addSuffix: true, locale: dateLocale })}
           </span>
-          <span className="text-[#6b7280] text-[10px]">
+          <span className="text-[#8b949e] text-[10px]">
             ({format(lastRunDate, 'HH:mm:ss')})
           </span>
         </div>
@@ -63,7 +63,7 @@ export function SystemStatus({ lastRun, nextRun }: SystemStatusProps) {
 
         {/* Next Run */}
         <div className="flex items-center gap-2">
-          <span className="text-[#6b7280] text-xs">next_run:</span>
+          <span className="text-[#8b949e] text-xs">next_run:</span>
           <span className="text-[#00ffff] text-xs">
             {nextRunLabel}
           </span>
@@ -73,7 +73,7 @@ export function SystemStatus({ lastRun, nextRun }: SystemStatusProps) {
 
         {/* Uptime */}
         <div className="flex items-center gap-2">
-          <span className="text-[#6b7280] text-xs">uptime:</span>
+          <span className="text-[#8b949e] text-xs">uptime:</span>
           <span className="text-[#f1fa8c] text-xs">99.9%</span>
         </div>
       </div>

--- a/website/src/components/TerminalWindow.tsx
+++ b/website/src/components/TerminalWindow.tsx
@@ -27,7 +27,7 @@ export function TerminalWindow({
           </div>
         )}
         <div className="flex-1 text-center">
-          <span className="text-[10px] text-[#6b7280] tracking-wider">
+          <span className="text-[10px] text-[#8b949e] tracking-wider">
             {title}
           </span>
         </div>
@@ -70,7 +70,7 @@ export function TerminalLine({
         </div>
       )}
       {output && (
-        <div className="text-[#6b7280] ml-4">
+        <div className="text-[#8b949e] ml-4">
           {output}
         </div>
       )}
@@ -141,7 +141,7 @@ export function TerminalProgress({
     <div className="space-y-1">
       {label && (
         <div className="flex justify-between text-xs">
-          <span className="text-[#6b7280]">{label}</span>
+          <span className="text-[#8b949e]">{label}</span>
           {showPercentage && (
             <span className="text-[#c0c0c0]">{percentage}%</span>
           )}

--- a/website/src/components/details/AgentDetail.tsx
+++ b/website/src/components/details/AgentDetail.tsx
@@ -136,14 +136,14 @@ export function AgentDetail({ data }: AgentDetailProps) {
       {/* Description */}
       {agent.description && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.agentDescription')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.agentDescription')}</div>
           <p className="text-sm text-[#c0c0c0] leading-relaxed">{agent.description}</p>
         </div>
       )}
 
       {/* Personality Traits */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-4">{t('detail.personalityProfile')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-4">{t('detail.personalityProfile')}</div>
         <div className="space-y-4">
           {personalityTraits.map((trait, idx) => (
             <motion.div
@@ -165,7 +165,7 @@ export function AgentDetail({ data }: AgentDetailProps) {
 
       {/* Role Perspective */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.rolePerspective')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.rolePerspective')}</div>
         <div className="text-sm text-[#c0c0c0]">
           {t(`role.${agent.role}.perspective`)}
         </div>
@@ -173,14 +173,14 @@ export function AgentDetail({ data }: AgentDetailProps) {
 
       {/* Personality Radar (ASCII style) */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-4">{t('detail.traitRadar')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-4">{t('detail.traitRadar')}</div>
         <div className="grid grid-cols-2 gap-4 text-center">
           {personalityTraits.map((trait) => {
             const value = agent.personality[trait.key as keyof typeof agent.personality];
             const bars = Math.round(value);
             return (
               <div key={trait.key} className="space-y-1">
-                <div className="text-xs text-[#6b7280]">{trait.label}</div>
+                <div className="text-xs text-[#8b949e]">{trait.label}</div>
                 <div className="text-[#39ff14] font-mono text-sm">
                   {'█'.repeat(bars)}
                   <span className="text-[#21262d]">{'░'.repeat(10 - bars)}</span>

--- a/website/src/components/details/DebateDetail.tsx
+++ b/website/src/components/details/DebateDetail.tsx
@@ -117,19 +117,19 @@ export function DebateDetail({ data }: DebateDetailProps) {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="card-cli p-3 text-center">
           <div className="text-2xl font-bold text-[#ff6b35]">{messages.length}</div>
-          <div className="text-xs text-[#6b7280]">{t('detail.messages')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.messages')}</div>
         </div>
         <div className="card-cli p-3 text-center">
           <div className="text-2xl font-bold text-[#00ffff]">{debate.participants.length}</div>
-          <div className="text-xs text-[#6b7280]">{t('detail.participants')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.participants')}</div>
         </div>
         <div className="card-cli p-3 text-center">
           <div className="text-2xl font-bold text-[#bd93f9]">{debate.round_number}</div>
-          <div className="text-xs text-[#6b7280]">{t('detail.currentRound')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.currentRound')}</div>
         </div>
         <div className="card-cli p-3 text-center">
           <div className="text-2xl font-bold text-[#39ff14]">{debate.max_rounds}</div>
-          <div className="text-xs text-[#6b7280]">{t('detail.maxRounds')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.maxRounds')}</div>
         </div>
       </div>
 
@@ -161,7 +161,7 @@ export function DebateDetail({ data }: DebateDetailProps) {
 
       {/* Participants */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.participants')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.participants')}</div>
         <div className="flex flex-wrap gap-2">
           {debate.participants.map((participant, idx) => (
             <motion.span
@@ -229,23 +229,23 @@ export function DebateDetail({ data }: DebateDetailProps) {
       {/* Outcome */}
       {debate.outcome && (
         <div className="card-cli p-4 border-l-2 border-[#39ff14]">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.outcome')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.outcome')}</div>
           <p className="text-sm text-[#c0c0c0] leading-relaxed">{debate.outcome}</p>
         </div>
       )}
 
       {/* Timestamps */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.timestamps')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.timestamps')}</div>
         <div className="grid grid-cols-2 gap-2 text-xs">
           <div>
-            <span className="text-[#6b7280]">{t('detail.startedAt')}: </span>
+            <span className="text-[#8b949e]">{t('detail.startedAt')}: </span>
             <span className="text-[#c0c0c0]">
               {formatLocalDateTime(debate.started_at, locale)}
             </span>
           </div>
           <div>
-            <span className="text-[#6b7280]">{t('detail.completedAt')}: </span>
+            <span className="text-[#8b949e]">{t('detail.completedAt')}: </span>
             <span className="text-[#c0c0c0]">
               {debate.completed_at ? formatLocalDateTime(debate.completed_at, locale) : t('detail.inProgress')}
             </span>

--- a/website/src/components/details/IdeaDetail.tsx
+++ b/website/src/components/details/IdeaDetail.tsx
@@ -126,26 +126,26 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
       {/* Stats Summary */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.ideaScore')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.ideaScore')}</div>
           <ScoreGauge value={idea.score} maxValue={10} label={t('detail.potential')} color="green" />
         </div>
 
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.debatesCount')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.debatesCount')}</div>
           <div className="text-3xl font-bold text-[#ff6b35]">{debates.length}</div>
-          <div className="text-xs text-[#6b7280]">{t('detail.rounds')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.rounds')}</div>
         </div>
 
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.plansCount')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.plansCount')}</div>
           <div className="text-3xl font-bold text-[#00ffff]">{plans.length}</div>
-          <div className="text-xs text-[#6b7280]">{t('detail.versions')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.versions')}</div>
         </div>
       </div>
 
       {/* Full Description or Summary */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">
+        <div className="text-xs text-[#8b949e] uppercase mb-2">
           {idea.description ? t('detail.fullDescription') : t('detail.summary')}
         </div>
         <div className="max-h-96 overflow-y-auto">
@@ -170,7 +170,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
 
       {/* Idea Journey Timeline */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-4">{t('detail.ideaJourney')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-4">{t('detail.ideaJourney')}</div>
         <IdeaJourney idea={idea} debates={debates} plans={plans} />
       </div>
 
@@ -191,7 +191,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
       {debates.length > 0 && debates[0].messages && debates[0].messages.length > 0 && (
         <div className="card-cli p-4">
           <div className="flex items-center justify-between mb-4">
-            <div className="text-xs text-[#6b7280] uppercase">{t('detail.debateTimeline')}</div>
+            <div className="text-xs text-[#8b949e] uppercase">{t('detail.debateTimeline')}</div>
             <button
               onClick={() => setExpandedMessages(!expandedMessages)}
               className="text-xs text-[#00ffff] hover:text-[#39ff14] transition-colors"
@@ -220,11 +220,11 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
                       <span className="text-[#00ffff] font-bold text-sm">{msg.agent_name}</span>
                       {msg.agent_handle && (
-                        <span className="text-xs text-[#6b7280]">@{msg.agent_handle}</span>
+                        <span className="text-xs text-[#8b949e]">@{msg.agent_handle}</span>
                       )}
                       <TerminalBadge variant="purple">{msg.message_type}</TerminalBadge>
                       {msg.created_at && (
-                        <span className="text-xs text-[#6b7280]">
+                        <span className="text-xs text-[#8b949e]">
                           {new Date(msg.created_at).toLocaleTimeString()}
                         </span>
                       )}
@@ -239,7 +239,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
           </AnimatePresence>
 
           {!expandedMessages && (
-            <div className="text-sm text-[#6b7280] italic">
+            <div className="text-sm text-[#8b949e] italic">
               {t('detail.clickToShowMessages')}
             </div>
           )}
@@ -249,7 +249,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
       {/* Debates Summary */}
       {debates.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.debateHistory')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.debateHistory')}</div>
           <div className="space-y-2">
             {debates.map((debate, idx) => (
               <motion.div
@@ -266,7 +266,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
                 <TerminalBadge variant={debate.status === 'completed' ? 'green' : 'orange'}>
                   {debate.status}
                 </TerminalBadge>
-                <span className="text-xs text-[#6b7280]">
+                <span className="text-xs text-[#8b949e]">
                   {debate.messages?.length || debate.message_count || 0} {t('detail.messages')}
                 </span>
               </motion.div>
@@ -278,7 +278,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
       {/* Plans List */}
       {plans.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.planVersions')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.planVersions')}</div>
           <div className="space-y-2">
             {plans.map((plan, idx) => (
               <motion.div
@@ -304,7 +304,7 @@ export function IdeaDetail({ data }: IdeaDetailProps) {
       {/* Links */}
       {idea.github_issue_url && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.links')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.links')}</div>
           <a
             href={idea.github_issue_url}
             target="_blank"

--- a/website/src/components/details/PipelineDetail.tsx
+++ b/website/src/components/details/PipelineDetail.tsx
@@ -98,8 +98,8 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
 
   const statusColors = {
     active: { bg: 'bg-[#39ff14]/10', text: 'text-[#39ff14]', border: 'border-[#39ff14]' },
-    completed: { bg: 'bg-[#6b7280]/10', text: 'text-[#c0c0c0]', border: 'border-[#6b7280]' },
-    idle: { bg: 'bg-[#21262d]', text: 'text-[#6b7280]', border: 'border-[#21262d]' },
+    completed: { bg: 'bg-[#8b949e]/10', text: 'text-[#c0c0c0]', border: 'border-[#8b949e]' },
+    idle: { bg: 'bg-[#21262d]', text: 'text-[#8b949e]', border: 'border-[#21262d]' },
   };
 
   const colors = statusColors[status as keyof typeof statusColors] || statusColors.idle;
@@ -120,13 +120,13 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
       {/* Stage Header */}
       <div className={`text-center p-4 rounded border ${colors.border} ${colors.bg}`}>
         <div className={`text-3xl font-bold ${colors.text}`}>{count}</div>
-        <div className="text-sm text-[#6b7280] uppercase tracking-wider">{stageName}</div>
+        <div className="text-sm text-[#8b949e] uppercase tracking-wider">{stageName}</div>
         <div className="mt-2">
           <span className={`
             text-[10px] px-2 py-0.5 rounded uppercase tracking-wider
             ${status === 'active' ? 'bg-[#39ff14]/20 text-[#39ff14]' : ''}
-            ${status === 'completed' ? 'bg-[#6b7280]/20 text-[#c0c0c0]' : ''}
-            ${status === 'idle' ? 'bg-[#21262d] text-[#6b7280]' : ''}
+            ${status === 'completed' ? 'bg-[#8b949e]/20 text-[#c0c0c0]' : ''}
+            ${status === 'idle' ? 'bg-[#21262d] text-[#8b949e]' : ''}
           `}>
             {status}
           </span>
@@ -134,7 +134,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
       </div>
 
       {/* Stage Description */}
-      <div className="text-xs text-[#6b7280]">
+      <div className="text-xs text-[#8b949e]">
         <span className="text-[#bd93f9]"># </span>
         {stageId === 'signals' && 'Raw signals collected from various sources (RSS, GitHub, OnChain, etc.)'}
         {stageId === 'trends' && 'Analyzed trends extracted from collected signals'}
@@ -147,7 +147,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
       {/* Recent Items */}
       {stageData?.items?.length > 0 && (
         <div className="space-y-2">
-          <div className="text-[10px] text-[#6b7280] uppercase tracking-wider">
+          <div className="text-[10px] text-[#8b949e] uppercase tracking-wider">
             Recent {stageName}
           </div>
           {stageData.items.map((item: any, idx: number) => (
@@ -183,7 +183,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
                       ${item.status === 'pending' ? 'bg-[#00ffff]/10 text-[#00ffff]' : ''}
                       ${item.status === 'approved' ? 'bg-[#39ff14]/10 text-[#39ff14]' : ''}
                       ${item.status === 'rejected' ? 'bg-[#ff5555]/10 text-[#ff5555]' : ''}
-                      ${!['pending', 'approved', 'rejected'].includes(item.status) ? 'bg-[#6b7280]/10 text-[#6b7280]' : ''}
+                      ${!['pending', 'approved', 'rejected'].includes(item.status) ? 'bg-[#8b949e]/10 text-[#8b949e]' : ''}
                     `}>
                       {item.status}
                     </span>
@@ -212,7 +212,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
             {stageId === 'projects' && '📦'}
             {stageId === 'dev' && '🚀'}
           </div>
-          <div className="text-sm text-[#6b7280]">No items in this stage</div>
+          <div className="text-sm text-[#8b949e]">No items in this stage</div>
           <div className="text-[10px] text-[#3b3b3b] mt-1">
             {stageId === 'signals' && 'Run signal collection to gather data'}
             {stageId === 'trends' && 'Run trend analysis to identify patterns'}
@@ -227,14 +227,14 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
       {/* Status Counts for Ideas */}
       {stageId === 'ideas' && stageData?.statusCounts && (
         <div className="border-t border-[#21262d] pt-4">
-          <div className="text-[10px] text-[#6b7280] mb-2 uppercase tracking-wider">
+          <div className="text-[10px] text-[#8b949e] mb-2 uppercase tracking-wider">
             Status breakdown
           </div>
           <div className="grid grid-cols-3 gap-2">
             {Object.entries(stageData.statusCounts).map(([status, count]) => (
               <div key={status} className="text-center p-2 bg-[#0d1117] rounded">
                 <div className="text-sm font-bold text-[#c0c0c0]">{count as number}</div>
-                <div className="text-[10px] text-[#6b7280]">{status}</div>
+                <div className="text-[10px] text-[#8b949e]">{status}</div>
               </div>
             ))}
           </div>

--- a/website/src/components/details/PlanDetail.tsx
+++ b/website/src/components/details/PlanDetail.tsx
@@ -248,7 +248,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
                 ${activeTab === tab.key
                   ? 'text-[#39ff14] border-[#39ff14]'
                   : hasContent
-                    ? 'text-[#6b7280] border-transparent hover:text-[#c0c0c0]'
+                    ? 'text-[#8b949e] border-transparent hover:text-[#c0c0c0]'
                     : 'text-[#3b3b3b] border-transparent cursor-not-allowed'
                 }
               `}
@@ -274,7 +274,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
             </pre>
           </motion.div>
         ) : (
-          <div className="text-center py-12 text-[#6b7280]">
+          <div className="text-center py-12 text-[#8b949e]">
             {t('detail.noContent')}
           </div>
         )}
@@ -282,16 +282,16 @@ export function PlanDetail({ data }: PlanDetailProps) {
 
       {/* Metadata */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.metadata')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.metadata')}</div>
         <div className="grid grid-cols-2 gap-2 text-xs">
           <div>
-            <span className="text-[#6b7280]">{t('detail.createdAt')}: </span>
+            <span className="text-[#8b949e]">{t('detail.createdAt')}: </span>
             <span className="text-[#c0c0c0]">
               {formatLocalDateTime(plan.created_at, locale)}
             </span>
           </div>
           <div>
-            <span className="text-[#6b7280]">{t('detail.updatedAt')}: </span>
+            <span className="text-[#8b949e]">{t('detail.updatedAt')}: </span>
             <span className="text-[#c0c0c0]">
               {formatLocalDateTime(plan.updated_at, locale)}
             </span>
@@ -302,7 +302,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
       {/* Links */}
       {plan.github_issue_url && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.links')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.links')}</div>
           <a
             href={plan.github_issue_url}
             target="_blank"
@@ -317,7 +317,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
 
       {/* Project Generation Section */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-3">
+        <div className="text-xs text-[#8b949e] uppercase mb-3">
           {locale === 'ko' ? '프로젝트 생성' : 'Project Generation'}
         </div>
 
@@ -337,7 +337,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
                 {projectState.project.name}
               </span>
             </div>
-            <div className="text-xs text-[#6b7280]">
+            <div className="text-xs text-[#8b949e]">
               <span>{locale === 'ko' ? '경로: ' : 'Path: '}</span>
               <code className="text-[#00ffff]">{projectState.project.directory_path}</code>
             </div>
@@ -354,13 +354,13 @@ export function PlanDetail({ data }: PlanDetailProps) {
                 )}
               </div>
             )}
-            <div className="text-xs text-[#6b7280]">
+            <div className="text-xs text-[#8b949e]">
               {locale === 'ko' ? '생성된 파일: ' : 'Files generated: '}
               <span className="text-[#39ff14]">{projectState.project.files_generated}</span>
             </div>
             <button
               onClick={() => handleGenerateProject()}
-              className="w-full mt-2 px-4 py-2 text-sm border border-[#6b7280] text-[#6b7280] hover:border-[#00ffff] hover:text-[#00ffff] rounded transition-colors"
+              className="w-full mt-2 px-4 py-2 text-sm border border-[#8b949e] text-[#8b949e] hover:border-[#00ffff] hover:text-[#00ffff] rounded transition-colors"
             >
               $ regenerate --force
             </button>
@@ -385,7 +385,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
 
             {/* Progress Steps */}
             <div className="border border-[#21262d] rounded p-3 space-y-2">
-              <div className="text-xs text-[#6b7280] uppercase mb-2">
+              <div className="text-xs text-[#8b949e] uppercase mb-2">
                 {locale === 'ko' ? '생성 단계' : 'Generation Steps'}
               </div>
               {[
@@ -398,10 +398,10 @@ export function PlanDetail({ data }: PlanDetailProps) {
               ].map((item, idx) => (
                 <div key={item.step} className="flex items-center gap-2 text-xs">
                   <span className="w-4 text-center">{item.icon}</span>
-                  <span className={idx < 2 ? 'text-[#39ff14]' : 'text-[#6b7280]'}>
+                  <span className={idx < 2 ? 'text-[#39ff14]' : 'text-[#8b949e]'}>
                     {idx < 2 ? '✓' : idx === 2 ? '●' : '○'}
                   </span>
-                  <span className={idx <= 2 ? 'text-[#c0c0c0]' : 'text-[#6b7280]'}>
+                  <span className={idx <= 2 ? 'text-[#c0c0c0]' : 'text-[#8b949e]'}>
                     {locale === 'ko' ? item.ko : item.en}
                   </span>
                 </div>
@@ -409,7 +409,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
             </div>
 
             {/* LLM Models Info */}
-            <div className="text-xs text-[#6b7280]">
+            <div className="text-xs text-[#8b949e]">
               <span>{locale === 'ko' ? '사용 모델: ' : 'Models: '}</span>
               <span className="text-[#bd93f9]">qwen3.5:9b</span>
               <span className="mx-1">+</span>
@@ -450,7 +450,7 @@ export function PlanDetail({ data }: PlanDetailProps) {
 
         {/* Plan not approved */}
         {!projectState.project && !projectState.generating && plan.status !== 'approved' && (
-          <div className="text-[#6b7280] text-sm">
+          <div className="text-[#8b949e] text-sm">
             {locale === 'ko'
               ? '프로젝트 생성은 승인된 플랜에서만 가능합니다.'
               : 'Project generation is only available for approved plans.'}

--- a/website/src/components/details/ProjectDetail.tsx
+++ b/website/src/components/details/ProjectDetail.tsx
@@ -8,6 +8,7 @@ import { formatLocalDateTime } from '@/lib/date';
 import type { ModalData } from '../modals/ModalProvider';
 import { TerminalBadge } from '../TerminalWindow';
 import { useModal } from '../modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 
 interface ProjectDetailProps {
   data: ModalData;
@@ -177,7 +178,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
 
       {/* Project Journey Visualization */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-4">
+        <div className="text-xs text-[#8b949e] uppercase mb-4">
           {locale === 'ko' ? '프로젝트 여정' : 'Project Journey'}
         </div>
         <div className="flex items-center justify-between gap-1 overflow-x-auto pb-2">
@@ -186,13 +187,18 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ delay: 0 }}
-            className={`flex flex-col items-center min-w-[60px] cursor-pointer ${debate ? 'hover:opacity-80' : 'opacity-40'}`}
-            onClick={() => debate && openModal('debate', { id: debate.id, title: debate.topic || 'Debate' })}
+            className={`flex flex-col items-center min-w-[60px] ${debate ? 'cursor-pointer hover:opacity-80' : 'opacity-40'}`}
+            {...(debate
+              ? clickableProps(
+                  () => openModal('debate', { id: debate.id, title: debate.topic || 'Debate' }),
+                  debate.topic || 'Debate'
+                )
+              : {})}
           >
             <div className={`w-10 h-10 rounded-full flex items-center justify-center text-lg ${debate ? 'bg-[#ff6b35]/20 border border-[#ff6b35]' : 'bg-[#21262d] border border-[#21262d]'}`}>
               💬
             </div>
-            <span className="text-[10px] text-[#6b7280] mt-1">Debate</span>
+            <span className="text-[10px] text-[#8b949e] mt-1">Debate</span>
             {debate && (
               <span className="text-[8px] text-[#ff6b35]">
                 {debate.participants?.length || 0} agents
@@ -208,13 +214,15 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ delay: 0.1 }}
-            className={`flex flex-col items-center min-w-[60px] cursor-pointer ${idea ? 'hover:opacity-80' : 'opacity-40'}`}
-            onClick={() => idea && openModal('idea', { id: idea.id, title: idea.title })}
+            className={`flex flex-col items-center min-w-[60px] ${idea ? 'cursor-pointer hover:opacity-80' : 'opacity-40'}`}
+            {...(idea
+              ? clickableProps(() => openModal('idea', { id: idea.id, title: idea.title }), idea.title)
+              : {})}
           >
             <div className={`w-10 h-10 rounded-full flex items-center justify-center text-lg ${idea ? 'bg-[#39ff14]/20 border border-[#39ff14]' : 'bg-[#21262d] border border-[#21262d]'}`}>
               💡
             </div>
-            <span className="text-[10px] text-[#6b7280] mt-1">Idea</span>
+            <span className="text-[10px] text-[#8b949e] mt-1">Idea</span>
             {idea && (
               <span className="text-[8px] text-[#39ff14]">
                 Score: {idea.score?.toFixed(1) || '-'}
@@ -230,13 +238,15 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ delay: 0.2 }}
-            className={`flex flex-col items-center min-w-[60px] cursor-pointer ${plan ? 'hover:opacity-80' : 'opacity-40'}`}
-            onClick={() => plan && openModal('plan', { id: plan.id, title: plan.title })}
+            className={`flex flex-col items-center min-w-[60px] ${plan ? 'cursor-pointer hover:opacity-80' : 'opacity-40'}`}
+            {...(plan
+              ? clickableProps(() => openModal('plan', { id: plan.id, title: plan.title }), plan.title)
+              : {})}
           >
             <div className={`w-10 h-10 rounded-full flex items-center justify-center text-lg ${plan ? 'bg-[#00ffff]/20 border border-[#00ffff]' : 'bg-[#21262d] border border-[#21262d]'}`}>
               📋
             </div>
-            <span className="text-[10px] text-[#6b7280] mt-1">Plan</span>
+            <span className="text-[10px] text-[#8b949e] mt-1">Plan</span>
             {plan && (
               <span className="text-[8px] text-[#00ffff]">
                 v{plan.version}
@@ -268,14 +278,14 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
       {/* Project Description from Plan */}
       {plan && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-3">
+          <div className="text-xs text-[#8b949e] uppercase mb-3">
             {locale === 'ko' ? '프로젝트 설명' : 'Project Description'}
           </div>
           <h4 className="text-[#c0c0c0] font-medium mb-2">
             {locale === 'ko' && plan.title_ko ? plan.title_ko : plan.title}
           </h4>
           {idea?.summary && (
-            <p className="text-sm text-[#6b7280] leading-relaxed">
+            <p className="text-sm text-[#8b949e] leading-relaxed">
               {locale === 'ko' && idea.summary_ko ? idea.summary_ko : idea.summary}
             </p>
           )}
@@ -285,7 +295,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
       {/* Tech Stack with Icons */}
       {project.tech_stack && Object.keys(project.tech_stack).length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-3">
+          <div className="text-xs text-[#8b949e] uppercase mb-3">
             {locale === 'ko' ? '기술 스택' : 'Tech Stack'}
           </div>
           <div className="grid grid-cols-2 gap-4">
@@ -293,7 +303,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
               <div className="flex items-center gap-3 p-3 bg-[#00ffff]/5 border border-[#00ffff]/30 rounded">
                 <span className="text-2xl">{getTechIcon(project.tech_stack.frontend)}</span>
                 <div>
-                  <div className="text-xs text-[#6b7280]">Frontend</div>
+                  <div className="text-xs text-[#8b949e]">Frontend</div>
                   <div className="text-sm text-[#00ffff] font-medium">{project.tech_stack.frontend}</div>
                 </div>
               </div>
@@ -302,7 +312,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
               <div className="flex items-center gap-3 p-3 bg-[#bd93f9]/5 border border-[#bd93f9]/30 rounded">
                 <span className="text-2xl">{getTechIcon(project.tech_stack.backend)}</span>
                 <div>
-                  <div className="text-xs text-[#6b7280]">Backend</div>
+                  <div className="text-xs text-[#8b949e]">Backend</div>
                   <div className="text-sm text-[#bd93f9] font-medium">{project.tech_stack.backend}</div>
                 </div>
               </div>
@@ -311,7 +321,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
               <div className="flex items-center gap-3 p-3 bg-[#ff6b35]/5 border border-[#ff6b35]/30 rounded">
                 <span className="text-2xl">{getTechIcon(project.tech_stack.database)}</span>
                 <div>
-                  <div className="text-xs text-[#6b7280]">Database</div>
+                  <div className="text-xs text-[#8b949e]">Database</div>
                   <div className="text-sm text-[#ff6b35] font-medium">{project.tech_stack.database}</div>
                 </div>
               </div>
@@ -320,7 +330,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
               <div className="flex items-center gap-3 p-3 bg-[#39ff14]/5 border border-[#39ff14]/30 rounded">
                 <span className="text-2xl">{getTechIcon(project.tech_stack.blockchain)}</span>
                 <div>
-                  <div className="text-xs text-[#6b7280]">Blockchain</div>
+                  <div className="text-xs text-[#8b949e]">Blockchain</div>
                   <div className="text-sm text-[#39ff14] font-medium">{project.tech_stack.blockchain}</div>
                 </div>
               </div>
@@ -328,7 +338,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
           </div>
           {project.tech_stack.additional && project.tech_stack.additional.length > 0 && (
             <div className="mt-4 pt-3 border-t border-[#21262d]">
-              <div className="text-xs text-[#6b7280] mb-2">
+              <div className="text-xs text-[#8b949e] mb-2">
                 {locale === 'ko' ? '추가 도구' : 'Additional Tools'}
               </div>
               <div className="flex flex-wrap gap-2">
@@ -345,7 +355,7 @@ export function ProjectDetail({ data }: ProjectDetailProps) {
 
       {/* Project Structure Visualization */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-3">
+        <div className="text-xs text-[#8b949e] uppercase mb-3">
           {locale === 'ko' ? '프로젝트 구조' : 'Project Structure'}
         </div>
         <div className="relative">
@@ -375,7 +385,7 @@ ${project.tech_stack?.blockchain ? `├── 📜 contracts/             # ${pr
       {/* Project Path */}
       {project.directory_path && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">
+          <div className="text-xs text-[#8b949e] uppercase mb-2">
             {locale === 'ko' ? '프로젝트 경로' : 'Project Path'}
           </div>
           <div className="flex items-center gap-2">
@@ -389,40 +399,40 @@ ${project.tech_stack?.blockchain ? `├── 📜 contracts/             # ${pr
 
       {/* Timeline */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-4">
+        <div className="text-xs text-[#8b949e] uppercase mb-4">
           {locale === 'ko' ? '타임라인' : 'Timeline'}
         </div>
         <div className="space-y-3">
           {debate?.started_at && (
             <div className="flex items-center gap-3">
               <div className="w-2 h-2 rounded-full bg-[#ff6b35]" />
-              <span className="text-xs text-[#6b7280] w-24">Debate</span>
+              <span className="text-xs text-[#8b949e] w-24">Debate</span>
               <span className="text-xs text-[#c0c0c0]">{formatLocalDateTime(debate.started_at, locale)}</span>
             </div>
           )}
           {idea?.created_at && (
             <div className="flex items-center gap-3">
               <div className="w-2 h-2 rounded-full bg-[#39ff14]" />
-              <span className="text-xs text-[#6b7280] w-24">Idea</span>
+              <span className="text-xs text-[#8b949e] w-24">Idea</span>
               <span className="text-xs text-[#c0c0c0]">{formatLocalDateTime(idea.created_at, locale)}</span>
             </div>
           )}
           {plan?.created_at && (
             <div className="flex items-center gap-3">
               <div className="w-2 h-2 rounded-full bg-[#00ffff]" />
-              <span className="text-xs text-[#6b7280] w-24">Plan</span>
+              <span className="text-xs text-[#8b949e] w-24">Plan</span>
               <span className="text-xs text-[#c0c0c0]">{formatLocalDateTime(plan.created_at, locale)}</span>
             </div>
           )}
           <div className="flex items-center gap-3">
             <div className="w-2 h-2 rounded-full bg-[#bd93f9]" />
-            <span className="text-xs text-[#6b7280] w-24">Project</span>
+            <span className="text-xs text-[#8b949e] w-24">Project</span>
             <span className="text-xs text-[#c0c0c0]">{formatLocalDateTime(project.created_at, locale)}</span>
           </div>
           {project.completed_at && (
             <div className="flex items-center gap-3">
               <div className="w-2 h-2 rounded-full bg-[#39ff14] shadow-[0_0_5px_#39ff14]" />
-              <span className="text-xs text-[#6b7280] w-24">Completed</span>
+              <span className="text-xs text-[#8b949e] w-24">Completed</span>
               <span className="text-xs text-[#39ff14]">{formatLocalDateTime(project.completed_at, locale)}</span>
             </div>
           )}
@@ -483,7 +493,7 @@ ${project.tech_stack?.blockchain ? `├── 📜 contracts/             # ${pr
               <div className="text-[#00ffff] font-medium">
                 {locale === 'ko' ? '프로젝트 생성 중...' : 'Generating project...'}
               </div>
-              <div className="text-xs text-[#6b7280] mt-1">
+              <div className="text-xs text-[#8b949e] mt-1">
                 {locale === 'ko'
                   ? 'LLM이 코드를 생성하고 있습니다. 잠시만 기다려주세요.'
                   : 'LLM is generating code. Please wait.'}
@@ -501,10 +511,10 @@ ${project.tech_stack?.blockchain ? `├── 📜 contracts/             # ${pr
               { step: 5, label: locale === 'ko' ? '파일 저장' : 'Saving files', done: false },
             ].map((item) => (
               <div key={item.step} className="flex items-center gap-2 text-xs">
-                <span className={item.done ? 'text-[#39ff14]' : 'text-[#6b7280]'}>
+                <span className={item.done ? 'text-[#39ff14]' : 'text-[#8b949e]'}>
                   {item.done ? '✓' : '○'}
                 </span>
-                <span className={item.done ? 'text-[#c0c0c0]' : 'text-[#6b7280]'}>
+                <span className={item.done ? 'text-[#c0c0c0]' : 'text-[#8b949e]'}>
                   {item.label}
                 </span>
               </div>
@@ -519,7 +529,7 @@ ${project.tech_stack?.blockchain ? `├── 📜 contracts/             # ${pr
           <div className="text-[#ff5555] font-medium mb-2">
             {locale === 'ko' ? '프로젝트 생성 실패' : 'Project generation failed'}
           </div>
-          <div className="text-xs text-[#6b7280]">
+          <div className="text-xs text-[#8b949e]">
             {locale === 'ko'
               ? 'Plan 상세 페이지에서 재시도할 수 있습니다.'
               : 'You can retry from the Plan detail page.'}

--- a/website/src/components/details/SignalDetail.tsx
+++ b/website/src/components/details/SignalDetail.tsx
@@ -108,12 +108,12 @@ export function SignalDetail({ data }: SignalDetailProps) {
       {/* Score Gauge */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.score')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.score')}</div>
           <ScoreGauge value={signal.score} maxValue={10} label={t('detail.relevance')} />
         </div>
 
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.sentiment')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.sentiment')}</div>
           <div className="flex items-center gap-2">
             <TerminalBadge variant={sentimentColor as 'green' | 'red' | 'cyan'}>
               {signal.sentiment || 'neutral'}
@@ -125,7 +125,7 @@ export function SignalDetail({ data }: SignalDetailProps) {
       {/* Summary */}
       {(signal.summary || signal.summary_ko) && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.summary')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.summary')}</div>
           <p className="text-sm text-[#c0c0c0] leading-relaxed">
             {getLocalizedText(signal.summary, signal.summary_ko)}
           </p>
@@ -135,7 +135,7 @@ export function SignalDetail({ data }: SignalDetailProps) {
       {/* Topics */}
       {signal.topics && signal.topics.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.topics')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.topics')}</div>
           <div className="flex flex-wrap gap-2">
             {signal.topics.map((topic, idx) => (
               <motion.span
@@ -155,7 +155,7 @@ export function SignalDetail({ data }: SignalDetailProps) {
       {/* Entities */}
       {signal.entities && signal.entities.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.entities')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.entities')}</div>
           <div className="flex flex-wrap gap-2">
             {signal.entities.map((entity, idx) => (
               <motion.span
@@ -174,17 +174,17 @@ export function SignalDetail({ data }: SignalDetailProps) {
 
       {/* Metadata */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.metadata')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.metadata')}</div>
         <div className="grid grid-cols-2 gap-2 text-xs">
           <div>
-            <span className="text-[#6b7280]">{t('detail.collectedAt')}: </span>
+            <span className="text-[#8b949e]">{t('detail.collectedAt')}: </span>
             <span className="text-[#c0c0c0]">
               {formatLocalDateTime(signal.collected_at, locale)}
             </span>
           </div>
           {signal.url && (
             <div>
-              <span className="text-[#6b7280]">{t('detail.source')}: </span>
+              <span className="text-[#8b949e]">{t('detail.source')}: </span>
               <a
                 href={signal.url}
                 target="_blank"

--- a/website/src/components/details/StatsDetail.tsx
+++ b/website/src/components/details/StatsDetail.tsx
@@ -79,7 +79,7 @@ export function StatsDetail({ data }: StatsDetailProps) {
         <div className="text-2xl font-bold text-[#39ff14]">
           {data.value as number}
         </div>
-        <div className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <div className="text-xs text-[#8b949e] uppercase tracking-wider">
           {data.label as string}
         </div>
       </div>
@@ -87,7 +87,7 @@ export function StatsDetail({ data }: StatsDetailProps) {
       {/* Stats breakdown based on type */}
       {statType === 'ideas' && statusData && (
         <div className="space-y-4">
-          <div className="text-xs text-[#6b7280]">
+          <div className="text-xs text-[#8b949e]">
             <span className="text-[#bd93f9]"># </span>
             Ideas breakdown by status
           </div>
@@ -102,7 +102,7 @@ export function StatsDetail({ data }: StatsDetailProps) {
 
       {statType === 'plans' && statusData && (
         <div className="space-y-4">
-          <div className="text-xs text-[#6b7280]">
+          <div className="text-xs text-[#8b949e]">
             <span className="text-[#bd93f9]"># </span>
             Plans breakdown by status
           </div>
@@ -117,12 +117,12 @@ export function StatsDetail({ data }: StatsDetailProps) {
 
       {statType === 'development' && (
         <div className="space-y-4">
-          <div className="text-xs text-[#6b7280]">
+          <div className="text-xs text-[#8b949e]">
             <span className="text-[#bd93f9]"># </span>
             Development status
           </div>
           <div className="text-center py-4">
-            <div className="text-[#6b7280] text-sm">No active development projects</div>
+            <div className="text-[#8b949e] text-sm">No active development projects</div>
             <div className="text-[10px] text-[#3b3b3b] mt-2">
               Projects will appear here when plans are approved
             </div>
@@ -132,7 +132,7 @@ export function StatsDetail({ data }: StatsDetailProps) {
 
       {statType === 'trends' && statusData && (
         <div className="space-y-4">
-          <div className="text-xs text-[#6b7280]">
+          <div className="text-xs text-[#8b949e]">
             <span className="text-[#bd93f9]"># </span>
             Trend analysis overview
           </div>
@@ -148,7 +148,7 @@ export function StatsDetail({ data }: StatsDetailProps) {
       {/* API Usage Stats */}
       {usage && (
         <div className="border-t border-[#21262d] pt-4">
-          <div className="text-xs text-[#6b7280] mb-3">
+          <div className="text-xs text-[#8b949e] mb-3">
             <span className="text-[#bd93f9]"># </span>
             API usage today
           </div>
@@ -157,20 +157,20 @@ export function StatsDetail({ data }: StatsDetailProps) {
               <div className="text-lg font-bold text-[#f1fa8c]">
                 ${usage.today.total_cost.toFixed(4)}
               </div>
-              <div className="text-[10px] text-[#6b7280]">Cost Today</div>
+              <div className="text-[10px] text-[#8b949e]">Cost Today</div>
             </div>
             <div className="p-2 bg-[#0d1117] rounded border border-[#21262d]">
               <div className="text-lg font-bold text-[#00ffff]">
                 {usage.today.total_requests}
               </div>
-              <div className="text-[10px] text-[#6b7280]">Requests Today</div>
+              <div className="text-[10px] text-[#8b949e]">Requests Today</div>
             </div>
           </div>
 
           {/* Provider breakdown */}
           {Object.keys(usage.today_by_provider).length > 0 && (
             <div className="mt-4">
-              <div className="text-[10px] text-[#6b7280] mb-2">By provider:</div>
+              <div className="text-[10px] text-[#8b949e] mb-2">By provider:</div>
               {Object.entries(usage.today_by_provider).map(([provider, stats]) => (
                 <div key={provider} className="flex justify-between text-xs py-1">
                   <span className="text-[#c0c0c0]">{provider}</span>
@@ -202,7 +202,7 @@ function StatBox({ label, value, color }: { label: string; value: number; color:
       <div className={`text-xl font-bold ${colorClasses[color as keyof typeof colorClasses]?.split(' ')[0]}`}>
         {value}
       </div>
-      <div className="text-[10px] text-[#6b7280]">{label}</div>
+      <div className="text-[10px] text-[#8b949e]">{label}</div>
     </motion.div>
   );
 }

--- a/website/src/components/details/TrendDetail.tsx
+++ b/website/src/components/details/TrendDetail.tsx
@@ -115,16 +115,16 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.trendScore')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.trendScore')}</div>
           <ScoreGauge value={trend.score} maxValue={10} label={t('detail.relevance')} color="purple" />
         </div>
 
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.signalCount')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.signalCount')}</div>
           <div className="text-3xl font-bold text-[#00ffff]">
             {trend.signal_count}
           </div>
-          <div className="text-xs text-[#6b7280]">{t('detail.relatedSignals')}</div>
+          <div className="text-xs text-[#8b949e]">{t('detail.relatedSignals')}</div>
         </div>
       </div>
 
@@ -139,7 +139,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Description */}
       {(trend.description || trend.description_ko) && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.description')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.description')}</div>
           <p className="text-sm text-[#c0c0c0] leading-relaxed">
             {getLocalizedText(trend.description, trend.description_ko)}
           </p>
@@ -149,7 +149,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Web3 Relevance */}
       {(trend as any).web3_relevance && (
         <div className="card-cli p-4 border-l-2 border-[#bd93f9]">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">Web3 Relevance</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">Web3 Relevance</div>
           <p className="text-sm text-[#c0c0c0] leading-relaxed">{(trend as any).web3_relevance}</p>
         </div>
       )}
@@ -157,7 +157,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Idea Seeds */}
       {(trend as any).idea_seeds && (trend as any).idea_seeds.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">💡 Idea Seeds</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">💡 Idea Seeds</div>
           <div className="space-y-2">
             {(trend as any).idea_seeds.map((seed: string, idx: number) => (
               <motion.div
@@ -178,7 +178,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Sample Headlines */}
       {(trend as any).sample_headlines && (trend as any).sample_headlines.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">📰 Sample Headlines</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">📰 Sample Headlines</div>
           <div className="space-y-2">
             {(trend as any).sample_headlines.map((headline: string, idx: number) => (
               <motion.div
@@ -198,7 +198,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Keywords */}
       {trend.keywords && trend.keywords.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.keywords')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.keywords')}</div>
           <div className="flex flex-wrap gap-2">
             {trend.keywords.map((keyword, idx) => (
               <motion.span
@@ -218,7 +218,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Sources */}
       {(trend as any).sources && (trend as any).sources.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">Sources</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">Sources</div>
           <div className="flex flex-wrap gap-2">
             {(trend as any).sources.map((source: string, idx: number) => (
               <span
@@ -235,7 +235,7 @@ export function TrendDetail({ data }: TrendDetailProps) {
       {/* Related Signals */}
       {trend.related_signals && trend.related_signals.length > 0 && (
         <div className="card-cli p-4">
-          <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.relatedSignals')}</div>
+          <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.relatedSignals')}</div>
           <div className="space-y-2 max-h-48 overflow-y-auto">
             {trend.related_signals.map((signal, idx) => (
               <motion.div
@@ -258,9 +258,9 @@ export function TrendDetail({ data }: TrendDetailProps) {
 
       {/* Metadata */}
       <div className="card-cli p-4">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">{t('detail.metadata')}</div>
+        <div className="text-xs text-[#8b949e] uppercase mb-2">{t('detail.metadata')}</div>
         <div className="text-xs">
-          <span className="text-[#6b7280]">{t('detail.analyzedAt')}: </span>
+          <span className="text-[#8b949e]">{t('detail.analyzedAt')}: </span>
           <span className="text-[#c0c0c0]">
             {formatLocalDateTime(trend.analyzed_at, locale)}
           </span>

--- a/website/src/components/modals/TerminalModal.tsx
+++ b/website/src/components/modals/TerminalModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useCallback, type ReactNode } from 'react';
+import { useEffect, useCallback, useRef, type ReactNode } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
 import type { ModalType, ModalData } from './ModalProvider';
@@ -58,8 +58,8 @@ function getModalTitle(type: ModalType, t: (key: string) => string): string {
     plan: t('modal.plan.title'),
     project: t('modal.project.title'),
     agent: t('modal.agent.title'),
-    stats: 'System Statistics',
-    pipeline: 'Pipeline Status',
+    stats: t('modal.stats.title'),
+    pipeline: t('modal.pipeline.title'),
   };
   return titles[type];
 }
@@ -82,12 +82,42 @@ function getModalColor(type: ModalType): string {
 
 export function TerminalModal({ type, data, onClose }: TerminalModalProps) {
   const { t } = useI18n();
+  const dialogRef = useRef<HTMLDivElement>(null);
 
-  // Handle ESC key
+  // ESC to close + Tab focus trap within the dialog.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
+        return;
+      }
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusable = Array.from(
+          dialogRef.current.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+        // No focusable children: keep focus on the dialog itself.
+        if (focusable.length === 0) {
+          event.preventDefault();
+          dialogRef.current.focus();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+        const insideDialog = dialogRef.current.contains(active);
+        // Wrap at the edges, and pull focus back in if it escaped (or sits on
+        // the dialog container, which has tabindex=-1).
+        if (event.shiftKey) {
+          if (!insideDialog || active === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (!insideDialog || active === last) {
+          event.preventDefault();
+          first.focus();
+        }
       }
     },
     [onClose]
@@ -99,6 +129,19 @@ export function TerminalModal({ type, data, onClose }: TerminalModalProps) {
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
+
+  // Lock background scroll, move focus into the dialog, and restore focus on close.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    document.body.style.overflow = 'hidden';
+    dialogRef.current?.focus();
+    return () => {
+      // Reset to the default (visible) rather than a captured value: the app only
+      // ever locks body scroll for modals, so this can't leave it stuck hidden.
+      document.body.style.overflow = '';
+      previouslyFocused?.focus?.();
+    };
+  }, []);
 
   // Handle outside click
   const handleOverlayClick = (event: React.MouseEvent) => {
@@ -123,6 +166,11 @@ export function TerminalModal({ type, data, onClose }: TerminalModalProps) {
         <div className="modal-scanline" />
 
         <motion.div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${type.toUpperCase()}: ${title}`}
+          tabIndex={-1}
           className="modal-container"
           initial={{ opacity: 0, scale: 0.95, y: 20 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -138,6 +186,7 @@ export function TerminalModal({ type, data, onClose }: TerminalModalProps) {
                   onClick={onClose}
                   className="terminal-dot red hover:brightness-125 transition-all cursor-pointer"
                   title={t('modal.close')}
+                  aria-label={t('modal.close')}
                 />
                 <div className="terminal-dot yellow" />
                 <div className="terminal-dot green" />
@@ -148,7 +197,7 @@ export function TerminalModal({ type, data, onClose }: TerminalModalProps) {
                 </span>
               </div>
               <div className="w-[52px] flex justify-end">
-                <span className="text-[10px] text-[#6b7280]">ESC</span>
+                <span className="text-[10px] text-[#8b949e]">ESC</span>
               </div>
             </div>
 
@@ -159,7 +208,7 @@ export function TerminalModal({ type, data, onClose }: TerminalModalProps) {
 
             {/* Footer */}
             <div className="modal-footer">
-              <div className="flex items-center justify-between text-[10px] text-[#6b7280]">
+              <div className="flex items-center justify-between text-[10px] text-[#8b949e]">
                 <span>ID: {data.id}</span>
                 <button
                   onClick={onClose}

--- a/website/src/components/visualization/AgentContribution.tsx
+++ b/website/src/components/visualization/AgentContribution.tsx
@@ -202,8 +202,8 @@ export function AgentContribution({
     switch (influence) {
       case 'high': return 'text-[#39ff14]';
       case 'medium': return 'text-[#ff6b35]';
-      case 'low': return 'text-[#6b7280]';
-      default: return 'text-[#6b7280]';
+      case 'low': return 'text-[#8b949e]';
+      default: return 'text-[#8b949e]';
     }
   };
 
@@ -212,7 +212,7 @@ export function AgentContribution({
       case 'advocate': return 'bg-[#39ff14]/20 text-[#39ff14] border-[#39ff14]/30';
       case 'challenger': return 'bg-[#ff6b35]/20 text-[#ff6b35] border-[#ff6b35]/30';
       case 'refiner': return 'bg-[#00ffff]/20 text-[#00ffff] border-[#00ffff]/30';
-      default: return 'bg-[#6b7280]/20 text-[#6b7280] border-[#6b7280]/30';
+      default: return 'bg-[#8b949e]/20 text-[#8b949e] border-[#8b949e]/30';
     }
   };
 
@@ -222,7 +222,7 @@ export function AgentContribution({
 
   if (agentStats.length === 0) {
     return (
-      <div className="text-center py-4 text-[#6b7280] text-sm">
+      <div className="text-center py-4 text-[#8b949e] text-sm">
         {t('agentContribution.noContributions')}
       </div>
     );
@@ -232,7 +232,7 @@ export function AgentContribution({
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('agentContribution.title')}
         </span>
         <span className="text-xs text-[#c0c0c0]">
@@ -264,19 +264,19 @@ export function AgentContribution({
               </div>
 
               <div className="flex items-center gap-4 text-xs mb-2">
-                <span className="text-[#6b7280]">
+                <span className="text-[#8b949e]">
                   {t('agentContribution.influence')}:
                   <span className={`ml-1 font-bold ${getInfluenceColor(agent.influence)}`}>
                     {t(`agentContribution.${agent.influence}`)}
                   </span>
                 </span>
-                <span className="text-[#6b7280]">
+                <span className="text-[#8b949e]">
                   {t('agentContribution.messages')}:
                   <span className="ml-1 text-[#c0c0c0]">{agent.messageCount}</span>
                 </span>
               </div>
 
-              <p className="text-xs text-[#6b7280] italic leading-relaxed line-clamp-2">
+              <p className="text-xs text-[#8b949e] italic leading-relaxed line-clamp-2">
                 "{agent.keyQuote}"
               </p>
             </motion.div>
@@ -294,19 +294,19 @@ export function AgentContribution({
         <div className="grid grid-cols-3 gap-2 text-center text-xs">
           <div>
             <div className="text-[#39ff14] font-bold">{summary.advocates}</div>
-            <div className="text-[#6b7280]">
+            <div className="text-[#8b949e]">
               {t('agentContribution.stance.advocate')} ({summary.advocatePercent}%)
             </div>
           </div>
           <div>
             <div className="text-[#ff6b35] font-bold">{summary.challengers}</div>
-            <div className="text-[#6b7280]">
+            <div className="text-[#8b949e]">
               {t('agentContribution.stance.challenger')} ({summary.challengerPercent}%)
             </div>
           </div>
           <div>
             <div className="text-[#00ffff] font-bold">{summary.refiners}</div>
-            <div className="text-[#6b7280]">
+            <div className="text-[#8b949e]">
               {t('agentContribution.stance.refiner')} ({summary.refinerPercent}%)
             </div>
           </div>
@@ -332,7 +332,7 @@ export function AgentContributionCompact({ messages }: { messages: DebateMessage
 
   return (
     <div className="flex items-center gap-3 text-xs">
-      <span className="text-[#6b7280]">{summary.total} {t('agentContribution.agents')}</span>
+      <span className="text-[#8b949e]">{summary.total} {t('agentContribution.agents')}</span>
       <div className="flex items-center gap-2">
         <span className="text-[#39ff14]" title={t('agentContribution.stance.advocate')}>
           +{summary.advocates}

--- a/website/src/components/visualization/CostDashboard.tsx
+++ b/website/src/components/visualization/CostDashboard.tsx
@@ -39,7 +39,7 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
           requests: data.requests,
           inputTokens: data.input_tokens,
           outputTokens: data.output_tokens,
-          color: colors[provider.toLowerCase()] || '#6b7280',
+          color: colors[provider.toLowerCase()] || '#8b949e',
         });
       });
     }
@@ -65,10 +65,10 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('costDashboard.title')}
         </span>
-        <span className="text-xs text-[#6b7280]">
+        <span className="text-xs text-[#8b949e]">
           {t('costDashboard.today')}
         </span>
       </div>
@@ -79,32 +79,32 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
           <div className="text-lg font-bold text-[#39ff14]">
             {formatCost(totalCost)}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('costDashboard.todayCost')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('costDashboard.todayCost')}</div>
         </div>
         <div className="p-3 rounded border border-[#00ffff]/30 bg-[#00ffff]/10">
           <div className="text-lg font-bold text-[#00ffff]">
             {usage.today.total_requests}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('costDashboard.requests')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('costDashboard.requests')}</div>
         </div>
         <div className="p-3 rounded border border-[#bd93f9]/30 bg-[#bd93f9]/10">
           <div className="text-lg font-bold text-[#bd93f9]">
             {formatTokens(usage.today.total_input_tokens + usage.today.total_output_tokens)}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('costDashboard.tokens')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('costDashboard.tokens')}</div>
         </div>
         <div className="p-3 rounded border border-[#ff6b35]/30 bg-[#ff6b35]/10">
           <div className="text-lg font-bold text-[#ff6b35]">
             {formatCost(usage.month_total)}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('costDashboard.monthTotal')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('costDashboard.monthTotal')}</div>
         </div>
       </div>
 
       {/* Budget Progress */}
       <div className="space-y-2">
         <div className="flex items-center justify-between text-xs">
-          <span className="text-[#6b7280]">{t('costDashboard.budgetUsage')}</span>
+          <span className="text-[#8b949e]">{t('costDashboard.budgetUsage')}</span>
           <span className={`font-bold ${
             budgetUsed >= 90 ? 'text-[#ff5555]' :
             budgetUsed >= 70 ? 'text-[#ff6b35]' :
@@ -125,7 +125,7 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
             }`}
           />
         </div>
-        <div className="flex items-center justify-between text-[10px] text-[#6b7280]">
+        <div className="flex items-center justify-between text-[10px] text-[#8b949e]">
           <span>{formatCost(usage.month_total)} {t('costDashboard.used')}</span>
           <span>{formatCost(monthlyBudget)} {t('costDashboard.budget')}</span>
         </div>
@@ -134,7 +134,7 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
       {/* Provider Breakdown */}
       {providerStats.length > 0 && (
         <div className="space-y-2 pt-3 border-t border-[#21262d]">
-          <div className="text-xs text-[#6b7280] uppercase">
+          <div className="text-xs text-[#8b949e] uppercase">
             {t('costDashboard.byProvider')}
           </div>
           <div className="space-y-2">
@@ -159,8 +159,8 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
                     <div className="flex items-center gap-3 text-xs">
                       {showDetails && (
                         <>
-                          <span className="text-[#6b7280]">{provider.requests} req</span>
-                          <span className="text-[#6b7280]">
+                          <span className="text-[#8b949e]">{provider.requests} req</span>
+                          <span className="text-[#8b949e]">
                             {formatTokens(provider.inputTokens + provider.outputTokens)} tok
                           </span>
                         </>
@@ -189,7 +189,7 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
       {/* History Chart */}
       {usage.history && usage.history.length > 0 && showDetails && (
         <div className="space-y-2 pt-3 border-t border-[#21262d]">
-          <div className="text-xs text-[#6b7280] uppercase">
+          <div className="text-xs text-[#8b949e] uppercase">
             {t('costDashboard.history')} ({usage.days} {t('costDashboard.days')})
           </div>
           <div className="flex items-end gap-1 h-16">
@@ -209,7 +209,7 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
               );
             })}
           </div>
-          <div className="flex justify-between text-[10px] text-[#6b7280]">
+          <div className="flex justify-between text-[10px] text-[#8b949e]">
             <span>{usage.history[usage.history.length - 14]?.date.slice(-5) || ''}</span>
             <span>{t('costDashboard.today')}</span>
           </div>
@@ -224,7 +224,7 @@ export function CostDashboard({ usage, showDetails = false }: CostDashboardProps
               className="w-2 h-2 rounded-full"
               style={{ backgroundColor: provider.color }}
             />
-            <span className="text-[#6b7280]">{provider.name}</span>
+            <span className="text-[#8b949e]">{provider.name}</span>
           </div>
         ))}
       </div>
@@ -242,17 +242,17 @@ export function CostDashboardCompact({ usage }: { usage: UsageResponse }) {
     <div className="flex items-center gap-3 text-xs">
       <div className="flex items-center gap-1">
         <span className="text-[#39ff14] font-bold">{formatCost(usage.today.total_cost)}</span>
-        <span className="text-[#6b7280]">today</span>
+        <span className="text-[#8b949e]">today</span>
       </div>
-      <span className="text-[#6b7280]">|</span>
+      <span className="text-[#8b949e]">|</span>
       <div className="flex items-center gap-1">
         <span className="text-[#00ffff] font-bold">{usage.today.total_requests}</span>
-        <span className="text-[#6b7280]">req</span>
+        <span className="text-[#8b949e]">req</span>
       </div>
-      <span className="text-[#6b7280]">|</span>
+      <span className="text-[#8b949e]">|</span>
       <div className="flex items-center gap-1">
         <span className="text-[#bd93f9] font-bold">{formatCost(usage.month_total)}</span>
-        <span className="text-[#6b7280]">month</span>
+        <span className="text-[#8b949e]">month</span>
       </div>
     </div>
   );

--- a/website/src/components/visualization/DebateConversation.tsx
+++ b/website/src/components/visualization/DebateConversation.tsx
@@ -82,7 +82,7 @@ const messageTypeColors: Record<string, string> = {
   synthesize: 'border-[#bd93f9]',
   question: 'border-[#f1fa8c]',
   answer: 'border-[#00ffff]',
-  default: 'border-[#6b7280]',
+  default: 'border-[#8b949e]',
 };
 
 const messageTypeIcons: Record<string, string> = {
@@ -98,7 +98,7 @@ const messageTypeIcons: Record<string, string> = {
 export function DebateConversation({ messages, locale }: DebateConversationProps) {
   if (messages.length === 0) {
     return (
-      <div className="text-center py-8 text-[#6b7280]">
+      <div className="text-center py-8 text-[#8b949e]">
         No messages in this debate yet.
       </div>
     );
@@ -127,7 +127,7 @@ export function DebateConversation({ messages, locale }: DebateConversationProps
               {message.agent_handle && (
                 <span className="text-xs text-[#00ffff]">@{message.agent_handle}</span>
               )}
-              <span className="text-[10px] text-[#6b7280] uppercase ml-auto">
+              <span className="text-[10px] text-[#8b949e] uppercase ml-auto">
                 {message.message_type}
               </span>
             </div>

--- a/website/src/components/visualization/DebateEvolution.tsx
+++ b/website/src/components/visualization/DebateEvolution.tsx
@@ -43,11 +43,11 @@ export function DebateEvolution({
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('debateEvolution.title')}
         </span>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-[#6b7280]">{t('debateEvolution.phase')}:</span>
+          <span className="text-xs text-[#8b949e]">{t('debateEvolution.phase')}:</span>
           <span className="text-xs text-[#ff6b35] font-bold">{phase}</span>
         </div>
       </div>
@@ -78,7 +78,7 @@ export function DebateEvolution({
                   ? round === currentRound
                     ? 'bg-[#ff6b35] text-black'
                     : 'bg-[#39ff14]/20 text-[#39ff14] border border-[#39ff14]'
-                  : 'bg-[#21262d] text-[#6b7280] border border-[#21262d]'
+                  : 'bg-[#21262d] text-[#8b949e] border border-[#21262d]'
                 }
               `}
             >
@@ -104,7 +104,7 @@ export function DebateEvolution({
                   <span className="text-[#ff6b35] font-bold text-sm">
                     R{summary.round}
                   </span>
-                  <span className="text-xs text-[#6b7280]">
+                  <span className="text-xs text-[#8b949e]">
                     {summary.messageCount} {t('debateEvolution.messages')}
                   </span>
                 </div>
@@ -114,7 +114,7 @@ export function DebateEvolution({
                     {summary.avgSentiment}
                   </span>
                   {/* Consensus Level */}
-                  <span className="text-xs text-[#6b7280]">
+                  <span className="text-xs text-[#8b949e]">
                     {t('debateEvolution.consensus')}: {summary.consensusLevel}%
                   </span>
                 </div>
@@ -128,7 +128,7 @@ export function DebateEvolution({
                   </span>
                 ))}
                 {summary.participants.length > 5 && (
-                  <span className="text-[10px] text-[#6b7280]">
+                  <span className="text-[10px] text-[#8b949e]">
                     +{summary.participants.length - 5}
                   </span>
                 )}
@@ -168,25 +168,25 @@ export function DebateEvolution({
           <div className="text-lg font-bold text-[#ff6b35]">
             {evolutionMetrics.totalMessages}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('debateEvolution.totalMessages')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('debateEvolution.totalMessages')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-bold text-[#00ffff]">
             {evolutionMetrics.uniqueParticipants}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('debateEvolution.participants')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('debateEvolution.participants')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-bold text-[#39ff14]">
             {evolutionMetrics.ideasNet}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('debateEvolution.netIdeas')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('debateEvolution.netIdeas')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-bold text-[#bd93f9]">
             {evolutionMetrics.avgConsensus}%
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('debateEvolution.avgConsensus')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('debateEvolution.avgConsensus')}</div>
         </div>
       </div>
     </div>
@@ -219,9 +219,9 @@ export function DebateEvolutionCompact({
       {/* Stats */}
       <div className="flex items-center gap-1.5 text-[10px]">
         <span className="text-[#ff6b35]">R{currentRound}/{maxRounds}</span>
-        <span className="text-[#6b7280]">•</span>
+        <span className="text-[#8b949e]">•</span>
         <span className="text-[#00ffff]">{messageCount}msg</span>
-        <span className="text-[#6b7280]">•</span>
+        <span className="text-[#8b949e]">•</span>
         <span className="text-[#bd93f9]">{participantCount}</span>
       </div>
     </div>
@@ -324,6 +324,6 @@ function getSentimentColor(sentiment: 'positive' | 'neutral' | 'negative' | 'mix
     case 'mixed':
       return 'bg-[#ff6b35]/20 text-[#ff6b35]';
     default:
-      return 'bg-[#6b7280]/20 text-[#6b7280]';
+      return 'bg-[#8b949e]/20 text-[#8b949e]';
   }
 }

--- a/website/src/components/visualization/DebateQualityMetrics.tsx
+++ b/website/src/components/visualization/DebateQualityMetrics.tsx
@@ -125,7 +125,7 @@ export function DebateQualityMetrics({
       case 'poor':
         return 'text-[#ff5555] bg-[#ff5555]/20';
       default:
-        return 'text-[#6b7280] bg-[#6b7280]/20';
+        return 'text-[#8b949e] bg-[#8b949e]/20';
     }
   };
 
@@ -140,7 +140,7 @@ export function DebateQualityMetrics({
       case 'poor':
         return 'bg-[#ff5555]';
       default:
-        return 'bg-[#6b7280]';
+        return 'bg-[#8b949e]';
     }
   };
 
@@ -148,11 +148,11 @@ export function DebateQualityMetrics({
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('debateQualityMetrics.title')}
         </span>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-[#6b7280]">{t('debateQualityMetrics.overall')}:</span>
+          <span className="text-xs text-[#8b949e]">{t('debateQualityMetrics.overall')}:</span>
           <span className={`text-sm font-bold ${
             overallScore >= 70 ? 'text-[#39ff14]' :
             overallScore >= 50 ? 'text-[#00ffff]' :
@@ -193,7 +193,7 @@ export function DebateQualityMetrics({
               <span className="text-xs text-[#c0c0c0]">{metric.label}</span>
               <div className="flex items-center gap-2">
                 {showDetails && (
-                  <span className="text-[10px] text-[#6b7280]">{metric.description}</span>
+                  <span className="text-[10px] text-[#8b949e]">{metric.description}</span>
                 )}
                 <span className={`text-[10px] px-1.5 py-0.5 rounded ${getRatingColor(metric.rating)}`}>
                   {metric.rating.toUpperCase()}
@@ -214,7 +214,7 @@ export function DebateQualityMetrics({
 
       {/* Phase Info */}
       <div className="pt-3 border-t border-[#21262d] flex items-center justify-between text-xs">
-        <span className="text-[#6b7280]">{t('debateQualityMetrics.currentPhase')}:</span>
+        <span className="text-[#8b949e]">{t('debateQualityMetrics.currentPhase')}:</span>
         <span className={`px-2 py-0.5 rounded ${
           phase === 'planning' ? 'bg-[#39ff14]/20 text-[#39ff14]' :
           phase === 'convergence' ? 'bg-[#00ffff]/20 text-[#00ffff]' :

--- a/website/src/components/visualization/DebateTimeline.tsx
+++ b/website/src/components/visualization/DebateTimeline.tsx
@@ -75,13 +75,13 @@ const messageTypeDotColors: Record<string, string> = {
   synthesize: 'bg-[#bd93f9]',
   question: 'bg-[#f1fa8c]',
   answer: 'bg-[#00ffff]',
-  default: 'bg-[#6b7280]',
+  default: 'bg-[#8b949e]',
 };
 
 export function DebateTimeline({ messages, locale }: DebateTimelineProps) {
   if (messages.length === 0) {
     return (
-      <div className="text-center py-8 text-[#6b7280]">
+      <div className="text-center py-8 text-[#8b949e]">
         No messages in this debate yet.
       </div>
     );

--- a/website/src/components/visualization/IdeaComparison.tsx
+++ b/website/src/components/visualization/IdeaComparison.tsx
@@ -52,7 +52,7 @@ export function IdeaComparison({
     if (score >= 8) return 'text-[#39ff14]';
     if (score >= 6) return 'text-[#00ffff]';
     if (score >= 4) return 'text-[#ff6b35]';
-    return 'text-[#6b7280]';
+    return 'text-[#8b949e]';
   };
 
   const getStatusColor = (status: string) => {
@@ -64,7 +64,7 @@ export function IdeaComparison({
       case 'in-development':
         return 'bg-[#ff6b35]/20 text-[#ff6b35]';
       case 'archived':
-        return 'bg-[#6b7280]/20 text-[#6b7280]';
+        return 'bg-[#8b949e]/20 text-[#8b949e]';
       default:
         return 'bg-[#bd93f9]/20 text-[#bd93f9]';
     }
@@ -83,11 +83,11 @@ export function IdeaComparison({
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('ideaComparison.title')}
         </span>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-[#6b7280]">
+          <span className="text-xs text-[#8b949e]">
             {selectedIds.length}/{maxCompare} {t('ideaComparison.selected')}
           </span>
           {selectedIds.length >= 2 && (
@@ -115,7 +115,7 @@ export function IdeaComparison({
                 p-2 rounded border cursor-pointer transition-colors
                 ${isSelected
                   ? 'border-[#39ff14] bg-[#39ff14]/10'
-                  : 'border-[#21262d] bg-black/20 hover:border-[#6b7280]'
+                  : 'border-[#21262d] bg-black/20 hover:border-[#8b949e]'
                 }
               `}
             >
@@ -149,7 +149,7 @@ export function IdeaComparison({
 
               {/* Header Row */}
               <div className="grid gap-2" style={{ gridTemplateColumns: `120px repeat(${selectedIdeas.length}, 1fr)` }}>
-                <div className="text-xs text-[#6b7280]">{t('ideaComparison.metric')}</div>
+                <div className="text-xs text-[#8b949e]">{t('ideaComparison.metric')}</div>
                 {selectedIdeas.map((idea) => (
                   <div key={idea.id} className="text-xs text-[#c0c0c0] font-bold line-clamp-2">
                     {idea.title.slice(0, 30)}...
@@ -169,7 +169,7 @@ export function IdeaComparison({
                     className="grid gap-2 py-2 border-b border-[#21262d]/50 last:border-0"
                     style={{ gridTemplateColumns: `120px repeat(${selectedIdeas.length}, 1fr)` }}
                   >
-                    <div className="text-xs text-[#6b7280]">{metric.label}</div>
+                    <div className="text-xs text-[#8b949e]">{metric.label}</div>
                     {selectedIdeas.map((idea) => {
                       const value = metric.getValue(idea);
                       const isBest = metric.format === 'score' && value === bestValue;
@@ -195,7 +195,7 @@ export function IdeaComparison({
                             <span className="text-xs text-[#c0c0c0]">{value}</span>
                           )}
                           {metric.format === 'date' && (
-                            <span className="text-xs text-[#6b7280]">{value}</span>
+                            <span className="text-xs text-[#8b949e]">{value}</span>
                           )}
                         </div>
                       );
@@ -207,7 +207,7 @@ export function IdeaComparison({
               {/* Summary Row */}
               <div className="mt-4 pt-3 border-t border-[#21262d]">
                 <div className="grid gap-2" style={{ gridTemplateColumns: `120px repeat(${selectedIdeas.length}, 1fr)` }}>
-                  <div className="text-xs text-[#6b7280]">{t('ideaComparison.summary')}</div>
+                  <div className="text-xs text-[#8b949e]">{t('ideaComparison.summary')}</div>
                   {selectedIdeas.map((idea) => (
                     <div key={idea.id} className="text-xs text-[#c0c0c0] line-clamp-3">
                       {idea.summary}
@@ -241,16 +241,16 @@ export function IdeaComparison({
           className="flex items-center justify-center gap-4 text-xs"
         >
           <div className="flex items-center gap-2">
-            <span className="text-[#6b7280]">{t('ideaComparison.avgScore')}:</span>
+            <span className="text-[#8b949e]">{t('ideaComparison.avgScore')}:</span>
             <span className={`font-bold ${getScoreColor(
               selectedIdeas.reduce((sum, i) => sum + i.score, 0) / selectedIdeas.length
             )}`}>
               {(selectedIdeas.reduce((sum, i) => sum + i.score, 0) / selectedIdeas.length).toFixed(1)}
             </span>
           </div>
-          <span className="text-[#6b7280]">|</span>
+          <span className="text-[#8b949e]">|</span>
           <div className="flex items-center gap-2">
-            <span className="text-[#6b7280]">{t('ideaComparison.bestScore')}:</span>
+            <span className="text-[#8b949e]">{t('ideaComparison.bestScore')}:</span>
             <span className="font-bold text-[#39ff14]">
               {Math.max(...selectedIdeas.map((i) => i.score)).toFixed(1)}
             </span>
@@ -289,7 +289,7 @@ export function IdeaComparisonMini({
               w-6 h-6 rounded text-[10px] font-bold transition-colors
               ${selected.includes(idea.id)
                 ? 'bg-[#39ff14] text-black'
-                : 'bg-[#21262d] text-[#6b7280] hover:bg-[#6b7280]/20'
+                : 'bg-[#21262d] text-[#8b949e] hover:bg-[#8b949e]/20'
               }
             `}
           >

--- a/website/src/components/visualization/IdeaJourney.tsx
+++ b/website/src/components/visualization/IdeaJourney.tsx
@@ -134,7 +134,7 @@ export function IdeaJourney({ idea, debates, plans }: IdeaJourneyProps) {
                       {step.label}
                     </div>
                     {step.details && (
-                      <div className="text-[10px] text-[#6b7280] truncate">
+                      <div className="text-[10px] text-[#8b949e] truncate">
                         {step.details}
                       </div>
                     )}
@@ -173,7 +173,7 @@ export function IdeaJourney({ idea, debates, plans }: IdeaJourneyProps) {
         {Object.entries(typeColors).map(([type, colors]) => (
           <div key={type} className="flex items-center gap-1">
             <div className={`w-2 h-2 rounded-full ${colors.bg} ${colors.border} border`} />
-            <span className="text-[#6b7280] uppercase">{type}</span>
+            <span className="text-[#8b949e] uppercase">{type}</span>
           </div>
         ))}
       </div>

--- a/website/src/components/visualization/IdeaNetwork.tsx
+++ b/website/src/components/visualization/IdeaNetwork.tsx
@@ -91,7 +91,7 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
     if (status === 'in-development') return '#ff6b35';
     if (score >= 7) return '#00ffff';
     if (score >= 5) return '#bd93f9';
-    return '#6b7280';
+    return '#8b949e';
   };
 
   const handleNodeClick = (nodeId: string) => {
@@ -112,10 +112,10 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('ideaNetwork.title')}
         </span>
-        <span className="text-xs text-[#6b7280]">
+        <span className="text-xs text-[#8b949e]">
           {nodes.length} {t('ideaNetwork.nodes')}, {links.length} {t('ideaNetwork.connections')}
         </span>
       </div>
@@ -219,19 +219,19 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
       <div className="flex flex-wrap gap-4 text-[10px] pt-2 border-t border-[#21262d]">
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded-full bg-[#39ff14]" />
-          <span className="text-[#6b7280]">{t('ideaNetwork.promoted')}</span>
+          <span className="text-[#8b949e]">{t('ideaNetwork.promoted')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded-full bg-[#ff6b35]" />
-          <span className="text-[#6b7280]">{t('ideaNetwork.inDev')}</span>
+          <span className="text-[#8b949e]">{t('ideaNetwork.inDev')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded-full bg-[#00ffff]" />
-          <span className="text-[#6b7280]">{t('ideaNetwork.highScore')}</span>
+          <span className="text-[#8b949e]">{t('ideaNetwork.highScore')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded-full bg-[#bd93f9]" />
-          <span className="text-[#6b7280]">{t('ideaNetwork.medScore')}</span>
+          <span className="text-[#8b949e]">{t('ideaNetwork.medScore')}</span>
         </div>
       </div>
 
@@ -255,20 +255,20 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
                   </span>
                   <span className={`text-sm font-bold ${
                     idea.score >= 7 ? 'text-[#39ff14]' :
-                    idea.score >= 5 ? 'text-[#00ffff]' : 'text-[#6b7280]'
+                    idea.score >= 5 ? 'text-[#00ffff]' : 'text-[#8b949e]'
                   }`}>
                     {idea.score.toFixed(1)}
                   </span>
                 </div>
                 <p className="text-xs text-[#c0c0c0] line-clamp-2">{idea.summary}</p>
                 <div className="flex items-center gap-2 mt-2 text-[10px]">
-                  <span className="text-[#6b7280]">{t('ideaNetwork.connected')}:</span>
+                  <span className="text-[#8b949e]">{t('ideaNetwork.connected')}:</span>
                   <span className="text-[#bd93f9]">{node.connections.length}</span>
-                  <span className="text-[#6b7280]">|</span>
+                  <span className="text-[#8b949e]">|</span>
                   <span className={`px-1.5 py-0.5 rounded ${
                     idea.status === 'promoted' ? 'bg-[#39ff14]/20 text-[#39ff14]' :
                     idea.status === 'in-development' ? 'bg-[#ff6b35]/20 text-[#ff6b35]' :
-                    'bg-[#6b7280]/20 text-[#6b7280]'
+                    'bg-[#8b949e]/20 text-[#8b949e]'
                   }`}>
                     {idea.status}
                   </span>
@@ -301,10 +301,10 @@ export function IdeaNetworkStats({ ideas }: { ideas: ApiIdea[] }) {
   return (
     <div className="flex items-center gap-2 text-xs">
       <span className="text-[#00ffff]">{stats.nodes}</span>
-      <span className="text-[#6b7280]">{t('ideaNetwork.nodes')}</span>
-      <span className="text-[#6b7280]">•</span>
+      <span className="text-[#8b949e]">{t('ideaNetwork.nodes')}</span>
+      <span className="text-[#8b949e]">•</span>
       <span className="text-[#bd93f9]">{stats.connections}</span>
-      <span className="text-[#6b7280]">{t('ideaNetwork.connections')}</span>
+      <span className="text-[#8b949e]">{t('ideaNetwork.connections')}</span>
     </div>
   );
 }

--- a/website/src/components/visualization/LiveDebateViewer.tsx
+++ b/website/src/components/visualization/LiveDebateViewer.tsx
@@ -81,7 +81,7 @@ const AGENT_STYLES: Record<string, AgentStyle> = {
   product_manager: { color: '#bd93f9', bgColor: 'rgba(189, 147, 249, 0.1)', borderColor: '#bd93f9' },
   community_builder: { color: '#ff6b35', bgColor: 'rgba(255, 107, 53, 0.1)', borderColor: '#ff6b35' },
   tech_lead: { color: '#39ff14', bgColor: 'rgba(57, 255, 20, 0.1)', borderColor: '#39ff14' },
-  default: { color: '#c0c0c0', bgColor: 'rgba(192, 192, 192, 0.1)', borderColor: '#6b7280' },
+  default: { color: '#c0c0c0', bgColor: 'rgba(192, 192, 192, 0.1)', borderColor: '#8b949e' },
 };
 
 export function LiveDebateViewer({
@@ -163,7 +163,7 @@ export function LiveDebateViewer({
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+          <span className="text-xs text-[#8b949e] uppercase tracking-wider">
             {t('liveDebate.title')}
           </span>
           {isLive && (
@@ -178,7 +178,7 @@ export function LiveDebateViewer({
           )}
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-[#6b7280]">
+          <span className="text-xs text-[#8b949e]">
             {messages.length} {t('liveDebate.messages')}
           </span>
           {!autoScroll && (
@@ -200,12 +200,12 @@ export function LiveDebateViewer({
         <span className={`px-2 py-0.5 rounded ${
           debate.status === 'in-progress' ? 'bg-[#ff6b35]/20 text-[#ff6b35]' :
           debate.status === 'completed' ? 'bg-[#39ff14]/20 text-[#39ff14]' :
-          'bg-[#6b7280]/20 text-[#6b7280]'
+          'bg-[#8b949e]/20 text-[#8b949e]'
         }`}>
           {debate.status}
         </span>
         <span className="text-[#bd93f9]">{debate.phase}</span>
-        <span className="text-[#6b7280]">
+        <span className="text-[#8b949e]">
           R{debate.round_number}/{debate.max_rounds}
         </span>
         <span className="text-[#00ffff]">
@@ -247,11 +247,11 @@ export function LiveDebateViewer({
                       <span className="text-xs" style={{ color: style.color }}>
                         @{msg.agent_handle || msg.agent_name}
                       </span>
-                      <span className="text-[10px] text-[#6b7280]">
+                      <span className="text-[10px] text-[#8b949e]">
                         {getMessageTypeIcon(msg.message_type)} {msg.message_type}
                       </span>
                     </div>
-                    <span className="text-[10px] text-[#6b7280]">
+                    <span className="text-[10px] text-[#8b949e]">
                       {formatTime(msg.created_at)}
                     </span>
                   </div>
@@ -292,11 +292,11 @@ export function LiveDebateViewer({
                     key={i}
                     animate={{ opacity: [0.3, 1, 0.3] }}
                     transition={{ repeat: Infinity, duration: 1, delay: i * 0.2 }}
-                    className="w-2 h-2 bg-[#6b7280] rounded-full"
+                    className="w-2 h-2 bg-[#8b949e] rounded-full"
                   />
                 ))}
               </div>
-              <span className="text-xs text-[#6b7280]">
+              <span className="text-xs text-[#8b949e]">
                 {t('liveDebate.agentsThinking')}
               </span>
             </motion.div>
@@ -308,7 +308,7 @@ export function LiveDebateViewer({
 
       {/* Participant Legend */}
       <div className="pt-3 border-t border-[#21262d]">
-        <div className="text-xs text-[#6b7280] uppercase mb-2">
+        <div className="text-xs text-[#8b949e] uppercase mb-2">
           {t('liveDebate.participants')}
         </div>
         <div className="flex flex-wrap gap-2">
@@ -325,7 +325,7 @@ export function LiveDebateViewer({
                 style={{ backgroundColor: style.bgColor, color: style.color }}
               >
                 <span>@{participant}</span>
-                <span className="text-[#6b7280]">({msgCount})</span>
+                <span className="text-[#8b949e]">({msgCount})</span>
               </div>
             );
           })}
@@ -357,9 +357,9 @@ export function LiveDebateIndicator({
           LIVE
         </motion.span>
       ) : (
-        <span className="text-xs text-[#6b7280]">{t('liveDebate.ended')}</span>
+        <span className="text-xs text-[#8b949e]">{t('liveDebate.ended')}</span>
       )}
-      <span className="text-xs text-[#6b7280]">{messageCount} msgs</span>
+      <span className="text-xs text-[#8b949e]">{messageCount} msgs</span>
     </div>
   );
 }

--- a/website/src/components/visualization/ScoreBreakdown.tsx
+++ b/website/src/components/visualization/ScoreBreakdown.tsx
@@ -80,7 +80,7 @@ export function ScoreBreakdown({
     <div className="space-y-4">
       {/* Header with total score */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('scoreBreakdown.title')}
         </span>
         <motion.span
@@ -104,7 +104,7 @@ export function ScoreBreakdown({
             >
               <div className="flex items-center justify-between text-xs mb-1">
                 <span className="text-[#c0c0c0]">{t(`scoreBreakdown.${dim.label}`)}</span>
-                <span className="text-[#6b7280]">
+                <span className="text-[#8b949e]">
                   {dim.value.toFixed(1)} <span className="text-[#3b3b3b]">({dim.weight}%)</span>
                 </span>
               </div>
@@ -130,12 +130,12 @@ export function ScoreBreakdown({
       >
         {consensus !== undefined && (
           <div className="flex items-center gap-2">
-            <span className="text-[#6b7280]">{t('scoreBreakdown.consensus')}:</span>
+            <span className="text-[#8b949e]">{t('scoreBreakdown.consensus')}:</span>
             <span className="text-[#00ffff] font-bold">{consensus}%</span>
           </div>
         )}
         <div className="flex items-center gap-2">
-          <span className="text-[#6b7280]">{t('scoreBreakdown.confidence')}:</span>
+          <span className="text-[#8b949e]">{t('scoreBreakdown.confidence')}:</span>
           <span className={`font-bold ${getConfidenceColor()}`}>
             {getConfidenceLabel()} <span className="text-[#3b3b3b]">(±{confidenceRange.toFixed(1)})</span>
           </span>

--- a/website/src/components/visualization/ScoreGauge.tsx
+++ b/website/src/components/visualization/ScoreGauge.tsx
@@ -48,7 +48,7 @@ export function ScoreGauge({
     <div className="space-y-2">
       {(label || showValue) && (
         <div className="flex justify-between items-center text-xs">
-          {label && <span className="text-[#6b7280]">{label}</span>}
+          {label && <span className="text-[#8b949e]">{label}</span>}
           {showValue && (
             <span className={colors.text}>
               {value.toFixed(1)}/{maxValue}

--- a/website/src/components/visualization/SignalLineage.tsx
+++ b/website/src/components/visualization/SignalLineage.tsx
@@ -50,7 +50,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
     if (score >= 8) return 'text-[#39ff14] border-[#39ff14]';
     if (score >= 6) return 'text-[#00ffff] border-[#00ffff]';
     if (score >= 4) return 'text-[#ff6b35] border-[#ff6b35]';
-    return 'text-[#6b7280] border-[#6b7280]';
+    return 'text-[#8b949e] border-[#8b949e]';
   };
 
   const getStatusColor = (status: string) => {
@@ -65,7 +65,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
       case 'in-progress':
         return 'bg-[#ff6b35]/20 text-[#ff6b35]';
       default:
-        return 'bg-[#6b7280]/20 text-[#6b7280]';
+        return 'bg-[#8b949e]/20 text-[#8b949e]';
     }
   };
 
@@ -73,7 +73,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('signalLineage.title')}
         </span>
       </div>
@@ -86,7 +86,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
           <div className="space-y-2">
             <div className="text-[10px] text-[#00ffff] uppercase tracking-wider mb-2 flex items-center gap-1">
               <span>SIGNALS</span>
-              <span className="text-[#6b7280]">({lineage.signals.length})</span>
+              <span className="text-[#8b949e]">({lineage.signals.length})</span>
             </div>
             <div className="space-y-1.5 max-h-48 overflow-y-auto pr-2">
               {lineage.signals.map((signal, idx) => (
@@ -103,7 +103,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
                   `}
                 >
                   <div className="flex items-center justify-between mb-1">
-                    <span className="text-[10px] text-[#6b7280]">{signal.source}</span>
+                    <span className="text-[10px] text-[#8b949e]">{signal.source}</span>
                     <span className={`text-xs font-bold ${getScoreColor(signal.score).split(' ')[0]}`}>
                       {signal.score.toFixed(1)}
                     </span>
@@ -153,7 +153,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
                 `}
               >
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-[10px] text-[#6b7280]">
+                  <span className="text-[10px] text-[#8b949e]">
                     {lineage.trend.signal_count} {t('signalLineage.signals')}
                   </span>
                   <span className="text-sm font-bold text-[#bd93f9]">
@@ -166,7 +166,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
               </motion.div>
             ) : (
               <div className="p-3 rounded border border-dashed border-[#21262d] text-center">
-                <span className="text-xs text-[#6b7280]">{t('signalLineage.noTrend')}</span>
+                <span className="text-xs text-[#8b949e]">{t('signalLineage.noTrend')}</span>
               </div>
             )}
           </div>
@@ -207,7 +207,7 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
               <div>
                 <div className="text-[10px] text-[#00ffff] uppercase tracking-wider mb-2 flex items-center gap-1">
                   <span>PLANS</span>
-                  <span className="text-[#6b7280]">({lineage.plans.length})</span>
+                  <span className="text-[#8b949e]">({lineage.plans.length})</span>
                 </div>
                 <div className="space-y-1.5">
                   {lineage.plans.map((plan, idx) => (
@@ -251,19 +251,19 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
       >
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#00ffff]" />
-          <span className="text-[#6b7280]">Signal</span>
+          <span className="text-[#8b949e]">Signal</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#bd93f9]" />
-          <span className="text-[#6b7280]">Trend</span>
+          <span className="text-[#8b949e]">Trend</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#39ff14]" />
-          <span className="text-[#6b7280]">Idea</span>
+          <span className="text-[#8b949e]">Idea</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#00ffff]" />
-          <span className="text-[#6b7280]">Plan</span>
+          <span className="text-[#8b949e]">Plan</span>
         </div>
       </motion.div>
     </div>
@@ -279,13 +279,13 @@ export function SignalLineageCompact({ signalCount, hasTrend, planCount }: {
   return (
     <div className="flex items-center gap-1 text-xs">
       <span className="text-[#00ffff]">{signalCount}</span>
-      <span className="text-[#6b7280]">→</span>
-      <span className={hasTrend ? 'text-[#bd93f9]' : 'text-[#6b7280]'}>
+      <span className="text-[#8b949e]">→</span>
+      <span className={hasTrend ? 'text-[#bd93f9]' : 'text-[#8b949e]'}>
         {hasTrend ? '1' : '0'}
       </span>
-      <span className="text-[#6b7280]">→</span>
+      <span className="text-[#8b949e]">→</span>
       <span className="text-[#39ff14]">1</span>
-      <span className="text-[#6b7280]">→</span>
+      <span className="text-[#8b949e]">→</span>
       <span className="text-[#00ffff]">{planCount}</span>
     </div>
   );

--- a/website/src/components/visualization/SignalSourceQuality.tsx
+++ b/website/src/components/visualization/SignalSourceQuality.tsx
@@ -93,7 +93,7 @@ export function SignalSourceQuality({ signals, showDetails = false }: SignalSour
       case 'poor':
         return 'bg-[#ff5555]/20 text-[#ff5555] border-[#ff5555]';
       default:
-        return 'bg-[#6b7280]/20 text-[#6b7280] border-[#6b7280]';
+        return 'bg-[#8b949e]/20 text-[#8b949e] border-[#8b949e]';
     }
   };
 
@@ -101,17 +101,17 @@ export function SignalSourceQuality({ signals, showDetails = false }: SignalSour
     if (score >= 8) return 'text-[#39ff14]';
     if (score >= 6) return 'text-[#00ffff]';
     if (score >= 4) return 'text-[#ff6b35]';
-    return 'text-[#6b7280]';
+    return 'text-[#8b949e]';
   };
 
   return (
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('signalSourceQuality.title')}
         </span>
-        <span className="text-xs text-[#6b7280]">
+        <span className="text-xs text-[#8b949e]">
           {sourceStats.length} {t('signalSourceQuality.sources')}
         </span>
       </div>
@@ -120,29 +120,29 @@ export function SignalSourceQuality({ signals, showDetails = false }: SignalSour
       <div className="grid grid-cols-4 gap-3">
         <div className="text-center p-2 rounded border border-[#21262d] bg-black/20">
           <div className="text-lg font-bold text-[#00ffff]">{totalSignals}</div>
-          <div className="text-[10px] text-[#6b7280]">{t('signalSourceQuality.totalSignals')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('signalSourceQuality.totalSignals')}</div>
         </div>
         <div className="text-center p-2 rounded border border-[#21262d] bg-black/20">
           <div className={`text-lg font-bold ${getScoreColor(avgOverallScore)}`}>
             {avgOverallScore.toFixed(1)}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('signalSourceQuality.avgScore')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('signalSourceQuality.avgScore')}</div>
         </div>
         <div className="text-center p-2 rounded border border-[#21262d] bg-black/20">
           <div className="text-lg font-bold text-[#39ff14]">
             {sourceStats.filter((s) => s.quality === 'excellent' || s.quality === 'good').length}
           </div>
-          <div className="text-[10px] text-[#6b7280]">{t('signalSourceQuality.quality')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('signalSourceQuality.quality')}</div>
         </div>
         <div className="text-center p-2 rounded border border-[#21262d] bg-black/20">
           <div className="text-lg font-bold text-[#bd93f9]">{sourceStats.length}</div>
-          <div className="text-[10px] text-[#6b7280]">{t('signalSourceQuality.sources')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('signalSourceQuality.sources')}</div>
         </div>
       </div>
 
       {/* Source Distribution Chart */}
       <div className="space-y-2">
-        <div className="text-xs text-[#6b7280] uppercase">
+        <div className="text-xs text-[#8b949e] uppercase">
           {t('signalSourceQuality.distribution')}
         </div>
         <div className="space-y-1.5">
@@ -167,7 +167,7 @@ export function SignalSourceQuality({ signals, showDetails = false }: SignalSour
                       className={`h-full ${getQualityColor(stat.quality).split(' ')[0]}`}
                     />
                   </div>
-                  <span className="text-xs text-[#6b7280] w-12 text-right">
+                  <span className="text-xs text-[#8b949e] w-12 text-right">
                     {stat.count}
                   </span>
                   <span className={`text-xs font-bold w-8 text-right ${getScoreColor(stat.avgScore)}`}>
@@ -186,7 +186,7 @@ export function SignalSourceQuality({ signals, showDetails = false }: SignalSour
       {/* Detailed View */}
       {showDetails && sourceStats.length > 0 && (
         <div className="space-y-2 pt-3 border-t border-[#21262d]">
-          <div className="text-xs text-[#6b7280] uppercase">
+          <div className="text-xs text-[#8b949e] uppercase">
             {t('signalSourceQuality.qualityBreakdown')}
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
@@ -214,19 +214,19 @@ export function SignalSourceQuality({ signals, showDetails = false }: SignalSour
       <div className="pt-3 border-t border-[#21262d] flex flex-wrap gap-3 text-[10px]">
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#39ff14]" />
-          <span className="text-[#6b7280]">{t('signalSourceQuality.excellent')}</span>
+          <span className="text-[#8b949e]">{t('signalSourceQuality.excellent')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#00ffff]" />
-          <span className="text-[#6b7280]">{t('signalSourceQuality.good')}</span>
+          <span className="text-[#8b949e]">{t('signalSourceQuality.good')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#ff6b35]" />
-          <span className="text-[#6b7280]">{t('signalSourceQuality.average')}</span>
+          <span className="text-[#8b949e]">{t('signalSourceQuality.average')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-[#ff5555]" />
-          <span className="text-[#6b7280]">{t('signalSourceQuality.poor')}</span>
+          <span className="text-[#8b949e]">{t('signalSourceQuality.poor')}</span>
         </div>
       </div>
     </div>
@@ -266,7 +266,7 @@ export function SignalSourceQualityCompact({ signals }: { signals: ApiSignal[] }
       <span className="text-[#00ffff]">{qualityCounts.good}</span>
       <span className="text-[#ff6b35]">{qualityCounts.average}</span>
       <span className="text-[#ff5555]">{qualityCounts.poor}</span>
-      <span className="text-[#6b7280]">{t('signalSourceQuality.sources')}</span>
+      <span className="text-[#8b949e]">{t('signalSourceQuality.sources')}</span>
     </div>
   );
 }

--- a/website/src/components/visualization/SignalTimeline.tsx
+++ b/website/src/components/visualization/SignalTimeline.tsx
@@ -93,7 +93,7 @@ export function SignalTimeline({
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('signalTimeline.title')}
         </span>
         <span className="text-xs text-[#c0c0c0]">
@@ -105,7 +105,7 @@ export function SignalTimeline({
       {showDetails && (
         <div className="relative">
           {/* Y-axis labels */}
-          <div className="absolute left-0 top-0 bottom-6 w-8 flex flex-col justify-between text-[8px] text-[#6b7280]">
+          <div className="absolute left-0 top-0 bottom-6 w-8 flex flex-col justify-between text-[8px] text-[#8b949e]">
             <span>{maxCount}</span>
             <span>{Math.round(maxCount / 2)}</span>
             <span>0</span>
@@ -150,7 +150,7 @@ export function SignalTimeline({
             </div>
 
             {/* X-axis labels */}
-            <div className="flex justify-between mt-1 text-[8px] text-[#6b7280] overflow-hidden">
+            <div className="flex justify-between mt-1 text-[8px] text-[#8b949e] overflow-hidden">
               {timelineData
                 .filter((_, idx) => {
                   // Show every 4th label for 24h, every label for 7d
@@ -176,17 +176,17 @@ export function SignalTimeline({
       >
         <div className="text-center">
           <div className="text-lg font-bold text-[#39ff14]">{totalSignals || total}</div>
-          <div className="text-[10px] text-[#6b7280]">{t('signalTimeline.total')}</div>
+          <div className="text-[10px] text-[#8b949e]">{t('signalTimeline.total')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-bold text-[#00ffff]">{average}</div>
-          <div className="text-[10px] text-[#6b7280]">
+          <div className="text-[10px] text-[#8b949e]">
             {t('signalTimeline.avg')}/{period === '24h' ? t('signalTimeline.hour') : t('signalTimeline.day')}
           </div>
         </div>
         <div className="text-center">
           <div className="text-lg font-bold text-[#bd93f9]">{peakSlot.label}</div>
-          <div className="text-[10px] text-[#6b7280]">
+          <div className="text-[10px] text-[#8b949e]">
             {t('signalTimeline.peak')} ({peakSlot.count})
           </div>
         </div>
@@ -196,15 +196,15 @@ export function SignalTimeline({
       <div className="flex justify-center gap-4 text-[10px]">
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-sm bg-[#39ff14]" />
-          <span className="text-[#6b7280]">{t('signalTimeline.recent')}</span>
+          <span className="text-[#8b949e]">{t('signalTimeline.recent')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-sm bg-[#00ffff]" />
-          <span className="text-[#6b7280]">{t('signalTimeline.peakTime')}</span>
+          <span className="text-[#8b949e]">{t('signalTimeline.peakTime')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-sm bg-[#39ff14]/50" />
-          <span className="text-[#6b7280]">{t('signalTimeline.normal')}</span>
+          <span className="text-[#8b949e]">{t('signalTimeline.normal')}</span>
         </div>
       </div>
     </div>

--- a/website/src/components/visualization/TrendHeatmap.tsx
+++ b/website/src/components/visualization/TrendHeatmap.tsx
@@ -96,10 +96,10 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('trendHeatmap.title')}
         </span>
-        <span className="text-xs text-[#6b7280]">
+        <span className="text-xs text-[#8b949e]">
           {trends.length} {t('trendHeatmap.trends')}
         </span>
       </div>
@@ -111,7 +111,7 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
           <div className="flex mb-2">
             <div className="w-20" /> {/* Spacer for category labels */}
             {DAYS.map(day => (
-              <div key={day} className="flex-1 text-center text-xs text-[#6b7280]">
+              <div key={day} className="flex-1 text-center text-xs text-[#8b949e]">
                 {day}
               </div>
             ))}
@@ -127,7 +127,7 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
               className="flex mb-1"
             >
               {/* Category Label */}
-              <div className="w-20 text-xs text-[#6b7280] flex items-center pr-2 truncate">
+              <div className="w-20 text-xs text-[#8b949e] flex items-center pr-2 truncate">
                 {row[0].category}
               </div>
 
@@ -161,13 +161,13 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
 
       {/* Legend */}
       <div className="flex items-center justify-between pt-3 border-t border-[#21262d]">
-        <span className="text-[10px] text-[#6b7280]">{t('trendHeatmap.less')}</span>
+        <span className="text-[10px] text-[#8b949e]">{t('trendHeatmap.less')}</span>
         <div className="flex gap-1">
           {['bg-[#0d1117]', 'bg-[#0e4429]', 'bg-[#006d32]', 'bg-[#26a641]', 'bg-[#39d353]', 'bg-[#39ff14]'].map((color, i) => (
             <div key={i} className={`w-3 h-3 rounded-sm ${color}`} />
           ))}
         </div>
-        <span className="text-[10px] text-[#6b7280]">{t('trendHeatmap.more')}</span>
+        <span className="text-[10px] text-[#8b949e]">{t('trendHeatmap.more')}</span>
       </div>
 
       {/* Hover Tooltip */}
@@ -181,7 +181,7 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
             <span className="text-xs text-[#00ffff]">
               {hoveredCell.category} - {hoveredCell.day}
             </span>
-            <span className="text-xs text-[#6b7280]">
+            <span className="text-xs text-[#8b949e]">
               {hoveredCell.trends.length} {t('trendHeatmap.trends')}
             </span>
           </div>
@@ -193,7 +193,7 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
               </div>
             ))}
             {hoveredCell.trends.length > 3 && (
-              <div className="text-[10px] text-[#6b7280]">
+              <div className="text-[10px] text-[#8b949e]">
                 +{hoveredCell.trends.length - 3} {t('trendHeatmap.more')}
               </div>
             )}

--- a/website/src/components/visualization/TrendSparkline.tsx
+++ b/website/src/components/visualization/TrendSparkline.tsx
@@ -94,7 +94,7 @@ export function TrendSparkline({
     <div className="space-y-3">
       {/* Header with momentum */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-[#6b7280] uppercase tracking-wider">
+        <span className="text-xs text-[#8b949e] uppercase tracking-wider">
           {t('trendSparkline.momentum')}
         </span>
         <motion.div
@@ -112,7 +112,7 @@ export function TrendSparkline({
       {/* Sparkline chart */}
       {showDetails && (
         <div className="space-y-1">
-          <div className="text-xs text-[#6b7280] mb-2">
+          <div className="text-xs text-[#8b949e] mb-2">
             {t('trendSparkline.last7Days')}:
           </div>
           <div className="space-y-1">
@@ -124,7 +124,7 @@ export function TrendSparkline({
                 transition={{ delay: idx * 0.05 }}
                 className="flex items-center gap-2 text-xs"
               >
-                <span className="w-8 text-[#6b7280] font-mono">{item.day}</span>
+                <span className="w-8 text-[#8b949e] font-mono">{item.day}</span>
                 <div className="flex-1 h-3 bg-[#21262d] rounded-sm overflow-hidden">
                   <motion.div
                     className={`h-full ${
@@ -136,7 +136,7 @@ export function TrendSparkline({
                   />
                 </div>
                 <span className={`w-8 text-right font-mono ${
-                  idx === history.length - 1 ? 'text-[#39ff14]' : 'text-[#6b7280]'
+                  idx === history.length - 1 ? 'text-[#39ff14]' : 'text-[#8b949e]'
                 }`}>
                   {item.count}
                 </span>
@@ -154,7 +154,7 @@ export function TrendSparkline({
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.4 }}
-        className="pt-2 border-t border-[#21262d] text-xs text-[#6b7280]"
+        className="pt-2 border-t border-[#21262d] text-xs text-[#8b949e]"
       >
         {t('trendSparkline.velocity')}: <span className="text-[#00ffff] font-bold">+{calculatedVelocity}</span> {t('trendSparkline.signalsPerDay')}
       </motion.div>

--- a/website/src/lib/a11y.ts
+++ b/website/src/lib/a11y.ts
@@ -1,0 +1,24 @@
+import type { KeyboardEvent } from 'react';
+
+/**
+ * Spreadable props that make a non-button element (e.g. a clickable <div> or
+ * framer-motion <motion.div>) behave like a button for keyboard and screen
+ * reader users: it becomes focusable, is announced as a button, and activates
+ * on Enter/Space in addition to click.
+ *
+ * Usage: <motion.div {...clickableProps(() => openModal(...))} ... />
+ */
+export function clickableProps(onActivate: () => void, label?: string | null) {
+  return {
+    role: 'button' as const,
+    tabIndex: 0,
+    'aria-label': label ?? undefined,
+    onClick: onActivate,
+    onKeyDown: (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onActivate();
+      }
+    },
+  };
+}

--- a/website/src/lib/i18n.tsx
+++ b/website/src/lib/i18n.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 
 type Locale = 'en' | 'ko';
 
@@ -126,6 +126,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'modal.plan.title': 'Plan Document',
     'modal.project.title': 'Project Details',
     'modal.agent.title': 'Agent Profile',
+    'modal.stats.title': 'System Statistics',
+    'modal.pipeline.title': 'Pipeline Status',
     'modal.close': 'Close',
 
     // Detail components
@@ -637,6 +639,8 @@ const translations: Record<Locale, Record<string, string>> = {
     'modal.plan.title': '플랜 문서',
     'modal.project.title': '프로젝트 상세',
     'modal.agent.title': '에이전트 프로필',
+    'modal.stats.title': '시스템 통계',
+    'modal.pipeline.title': '파이프라인 상태',
     'modal.close': '닫기',
 
     // Detail components
@@ -1038,7 +1042,34 @@ const translations: Record<Locale, Record<string, string>> = {
 const I18nContext = createContext<I18nContextType | null>(null);
 
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocale] = useState<Locale>('en');
+  const [locale, setLocaleState] = useState<Locale>('en');
+
+  // Restore the saved language preference after mount. This runs in an effect
+  // (not a lazy useState initializer) on purpose: localStorage is unavailable
+  // during SSR, and reading it during the initial client render would cause a
+  // hydration mismatch. Rendering 'en' first then switching avoids that.
+  useEffect(() => {
+    const saved = localStorage.getItem('moss-locale');
+    if (saved === 'en' || saved === 'ko') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLocaleState(saved);
+    }
+  }, []);
+
+  // Keep <html lang> and the saved preference in sync with the active locale
+  // (important for screen readers and correct hyphenation).
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    try {
+      localStorage.setItem('moss-locale', locale);
+    } catch {
+      // Ignore storage failures (e.g. private mode).
+    }
+  }, [locale]);
+
+  const setLocale = useCallback((next: Locale) => {
+    setLocaleState(next);
+  }, []);
 
   const t = useCallback(
     (key: string): string => {
@@ -1066,23 +1097,31 @@ export function LanguageToggle() {
   const { locale, setLocale } = useI18n();
 
   return (
-    <div className="flex items-center gap-1 rounded-lg border border-zinc-700 bg-zinc-800/50 p-0.5">
+    <div
+      role="group"
+      aria-label="Language selector"
+      className="flex items-center gap-1 rounded-lg border border-zinc-700 bg-zinc-800/50 p-0.5"
+    >
       <button
         onClick={() => setLocale('en')}
-        className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+        aria-label="Switch to English"
+        aria-pressed={locale === 'en'}
+        className={`rounded px-2.5 py-1.5 text-xs font-medium transition-colors ${
           locale === 'en'
             ? 'bg-zinc-600 text-white'
-            : 'text-zinc-400 hover:text-zinc-200'
+            : 'text-zinc-300 hover:text-white'
         }`}
       >
         EN
       </button>
       <button
         onClick={() => setLocale('ko')}
-        className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+        aria-label="한국어로 전환"
+        aria-pressed={locale === 'ko'}
+        className={`rounded px-2.5 py-1.5 text-xs font-medium transition-colors ${
           locale === 'ko'
             ? 'bg-zinc-600 text-white'
-            : 'text-zinc-400 hover:text-zinc-200'
+            : 'text-zinc-300 hover:text-white'
         }`}
       >
         KO


### PR DESCRIPTION
## Summary
Makes the dashboard genuinely usable and accessible on **both mobile and desktop**, addressing the gaps found in the UI/UX assessment. Evidence-gathered by screenshotting pages on both viewports; every change below was runtime-verified in a browser preview.

### Responsive (mobile)
- **Tab bars no longer clip on mobile.** The 5-tab rows (ideas/system/backlog) were cut off (`Plans`/`Projects` hidden) on narrow screens. Now `flex flex-wrap md:flex-nowrap` → wraps on mobile, stays single-row on desktop. *(both verified)*

### Accessibility (WCAG AA)
- **Contrast:** muted text `#6b7280` → `#8b949e` everywhere — **4.1:1 → 6.44:1** on `#0a0a0a` (was failing AA, now passes). *(ratio measured)*
- **Modal:** `role="dialog"` + `aria-modal` + `aria-label`, a **Tab focus-trap** (robust to 0/1 focusable + focus-escape), **background scroll-lock**, and **focus restore** to the trigger on close. *(verified: lock engages on open, releases on Escape; focus returns)*
- **Keyboard access:** mouse-only `<div>` cards that open modals (dashboard stats + recent projects, ideas trend/idea/plan/project cards, debate list, agent cards, project-detail flow) are now real buttons via a shared `clickableProps()` helper (`role=button`, `tabIndex`, Enter/Space). *(verified role/tabIndex/aria-label on stat cards)*
- **Reduced motion:** `<MotionConfig reducedMotion="user">` (framer-motion) + CSS media query.
- **`<html lang>`** now tracks the active locale (was hard-coded `ko`) and the choice persists to `localStorage`. Language toggle: `role=group` + `aria-pressed`.
- **Navigation:** landmark label, mobile-menu `aria-label`/`aria-expanded`/`aria-controls` + bigger touch target, decorative emoji `aria-hidden`.

### i18n
- Modal titles `System Statistics` / `Pipeline Status` → i18n keys (EN + KO).

## Adversarial review
Ran a 2-reviewer adversarial pass before finalizing. It caught real issues which are **fixed in this PR**: tab `flex-wrap` now `md:flex-nowrap` (desktop preserved); focus-trap edge cases hardened; modal-title i18n; keyboard access added. The reviewer's suggestion to capture/restore `body.overflow` was **rejected with cause** — that exact pattern caused an observed scroll-lock *leak*; the verified `''` reset is correct for this app (nothing else sets `body.overflow`).

## Testing
`npm run build` ✓; changed files eslint-clean. Runtime-verified on desktop (1280) and mobile (375): tab wrap/no-wrap, contrast, modal dialog semantics + scroll-lock release, dynamic `html lang`, keyboard-activatable cards.

## Follow-up (tracked, not blocking)
Keyboard access for a few **secondary** surfaces (system page filters, advanced visualization sub-components, transparency pages) — same helper, mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)