### PR TITLE
a11y(web): keyboard access for remaining secondary surfaces

### DIFF
--- a/website/src/app/projects/page.tsx
+++ b/website/src/app/projects/page.tsx
@@ -7,6 +7,7 @@ import { ApiClient, type ApiProject, type ApiPlan } from '@/lib/api';
 import { formatLocalDateTime } from '@/lib/date';
 import { TerminalWindow, TerminalBadge } from '@/components/TerminalWindow';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 
 interface ProjectWithPlan extends ApiProject {
   plan?: ApiPlan | null;
@@ -144,7 +145,7 @@ export default function ProjectsPage() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.05 }}
                 className="p-4 hover:bg-[#161b22] cursor-pointer transition-colors"
-                onClick={() => openModal('project', { id: project.id, title: project.name })}
+                {...clickableProps(() => openModal('project', { id: project.id, title: project.name }), project.name)}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">

--- a/website/src/app/system/page.tsx
+++ b/website/src/app/system/page.tsx
@@ -9,6 +9,7 @@ import { SignalTimeline } from '@/components/visualization/SignalTimeline';
 import { SignalSourceQuality } from '@/components/visualization/SignalSourceQuality';
 import { CostDashboard } from '@/components/visualization/CostDashboard';
 import { useModal } from '@/components/modals/useModal';
+import { clickableProps } from '@/lib/a11y';
 
 type ViewMode = 'status' | 'signals' | 'tech';
 
@@ -333,7 +334,7 @@ export default function SystemPage() {
                       initial={{ opacity: 0, x: -10 }}
                       animate={{ opacity: 1, x: 0 }}
                       transition={{ delay: idx * 0.01 }}
-                      onClick={() => openModal('signal', { ...signal, title: signal.title })}
+                      {...clickableProps(() => openModal('signal', { ...signal, title: signal.title }), signal.title)}
                       className="p-3 rounded border border-[#21262d] hover:border-[#00ffff] cursor-pointer transition-colors bg-black/20"
                     >
                       <div className="flex items-start gap-3">

--- a/website/src/app/transparency/debates/page.tsx
+++ b/website/src/app/transparency/debates/page.tsx
@@ -7,6 +7,7 @@ import { ApiClient, type ApiDebate } from '@/lib/api';
 import { formatLocalDate } from '@/lib/date';
 import { useModal } from '@/components/modals/useModal';
 import { TerminalWindow, TerminalBadge } from '@/components/TerminalWindow';
+import { clickableProps } from '@/lib/a11y';
 
 export default function DebatesPage() {
   const { t, locale } = useI18n();
@@ -153,7 +154,7 @@ export default function DebatesPage() {
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: idx * 0.02 }}
-                  onClick={() => handleDebateClick(debate)}
+                  {...clickableProps(() => handleDebateClick(debate), `${t('debates.session')} #${debate.id.slice(0, 8)}`)}
                   className="card-cli p-4 cursor-pointer hover:border-[#ff6b35] transition-colors"
                 >
                   <div className="flex items-center gap-4">

--- a/website/src/app/transparency/signals/page.tsx
+++ b/website/src/app/transparency/signals/page.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/lib/i18n';
 import { ApiClient, type ApiSignal } from '@/lib/api';
 import { useModal } from '@/components/modals/useModal';
 import { TerminalWindow, TerminalBadge } from '@/components/TerminalWindow';
+import { clickableProps } from '@/lib/a11y';
 
 export default function SignalsPage() {
   const { t } = useI18n();
@@ -143,7 +144,7 @@ export default function SignalsPage() {
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: idx * 0.02 }}
-                  onClick={() => handleSignalClick(signal)}
+                  {...clickableProps(() => handleSignalClick(signal), signal.title)}
                   className="card-cli p-4 cursor-pointer hover:border-[#00ffff] transition-colors"
                 >
                   <div className="flex items-start gap-4">

--- a/website/src/components/details/PipelineDetail.tsx
+++ b/website/src/components/details/PipelineDetail.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useI18n } from '@/lib/i18n';
 import { ApiClient } from '@/lib/api';
 import { formatLocalDate } from '@/lib/date';
+import { clickableProps } from '@/lib/a11y';
 import type { ModalData } from '../modals/ModalProvider';
 
 interface PipelineDetailProps {
@@ -157,7 +158,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
               animate={{ opacity: 1, x: 0 }}
               transition={{ delay: idx * 0.05 }}
               className="p-3 bg-[#0d1117] rounded border border-[#21262d] hover:border-[#39ff14]/50 transition-colors cursor-pointer"
-              onClick={() => {
+              {...clickableProps(() => {
                 // Navigate to the appropriate page
                 if (stageId === 'signals') {
                   router.push('/transparency/signals');
@@ -170,7 +171,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
                 } else if (stageId === 'projects') {
                   router.push('/projects');
                 }
-              }}
+              }, item.title)}
             >
               <div className="flex justify-between items-start">
                 <div className="flex-1 min-w-0">

--- a/website/src/components/visualization/IdeaComparison.tsx
+++ b/website/src/components/visualization/IdeaComparison.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
+import { clickableProps } from '@/lib/a11y';
 import type { ApiIdea } from '@/lib/api';
 
 interface IdeaComparisonProps {
@@ -110,7 +111,7 @@ export function IdeaComparison({
               key={idea.id}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
-              onClick={() => toggleSelect(idea.id)}
+              {...clickableProps(() => toggleSelect(idea.id), idea.title)}
               className={`
                 p-2 rounded border cursor-pointer transition-colors
                 ${isSelected

--- a/website/src/components/visualization/IdeaNetwork.tsx
+++ b/website/src/components/visualization/IdeaNetwork.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
+import { clickableProps } from '@/lib/a11y';
 import type { ApiIdea } from '@/lib/api';
 
 interface IdeaNetworkProps {
@@ -180,7 +181,7 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
                     className="cursor-pointer"
                     onMouseEnter={() => setHoveredNode(node.id)}
                     onMouseLeave={() => setHoveredNode(null)}
-                    onClick={() => handleNodeClick(node.id)}
+                    {...clickableProps(() => handleNodeClick(node.id), node.title)}
                   />
 
                   {/* Score Label */}

--- a/website/src/components/visualization/SignalLineage.tsx
+++ b/website/src/components/visualization/SignalLineage.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
+import { clickableProps } from '@/lib/a11y';
 
 interface SignalNode {
   id: string;
@@ -95,9 +96,9 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: idx * 0.05 }}
-                  onClick={() => onNodeClick?.('signal', signal.id)}
+                  {...(onNodeClick ? clickableProps(() => onNodeClick('signal', signal.id), signal.title) : {})}
                   className={`
-                    p-2 rounded border bg-black/20 cursor-pointer
+                    p-2 rounded border bg-black/20 ${onNodeClick ? 'cursor-pointer' : ''}
                     hover:bg-[#00ffff]/10 transition-colors
                     ${getScoreColor(signal.score)}
                   `}
@@ -146,9 +147,9 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
                 initial={{ opacity: 0, scale: 0.95 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 0.4 }}
-                onClick={() => onNodeClick?.('trend', lineage.trend!.id)}
+                {...(onNodeClick ? clickableProps(() => onNodeClick('trend', lineage.trend!.id), lineage.trend.name) : {})}
                 className={`
-                  p-3 rounded border-2 bg-[#bd93f9]/10 cursor-pointer
+                  p-3 rounded border-2 bg-[#bd93f9]/10 ${onNodeClick ? 'cursor-pointer' : ''}
                   hover:bg-[#bd93f9]/20 transition-colors border-[#bd93f9]
                 `}
               >
@@ -182,9 +183,9 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
                 initial={{ opacity: 0, scale: 0.95 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 0.6 }}
-                onClick={() => onNodeClick?.('idea', lineage.idea.id)}
+                {...(onNodeClick ? clickableProps(() => onNodeClick('idea', lineage.idea.id), lineage.idea.title) : {})}
                 className={`
-                  p-3 rounded border-2 bg-[#39ff14]/10 cursor-pointer
+                  p-3 rounded border-2 bg-[#39ff14]/10 ${onNodeClick ? 'cursor-pointer' : ''}
                   hover:bg-[#39ff14]/20 transition-colors border-[#39ff14]
                 `}
               >
@@ -216,8 +217,8 @@ export function SignalLineage({ lineage, onNodeClick }: SignalLineageProps) {
                       initial={{ opacity: 0, y: 10 }}
                       animate={{ opacity: 1, y: 0 }}
                       transition={{ delay: 0.7 + idx * 0.1 }}
-                      onClick={() => onNodeClick?.('plan', plan.id)}
-                      className="p-2 rounded border border-[#00ffff] bg-[#00ffff]/10 cursor-pointer hover:bg-[#00ffff]/20 transition-colors"
+                      {...(onNodeClick ? clickableProps(() => onNodeClick('plan', plan.id), plan.title) : {})}
+                      className={`p-2 rounded border border-[#00ffff] bg-[#00ffff]/10 ${onNodeClick ? 'cursor-pointer' : ''} hover:bg-[#00ffff]/20 transition-colors`}
                     >
                       <div className="flex items-center justify-between">
                         <span className="text-xs text-[#00ffff] font-bold">v{plan.version}</span>

--- a/website/src/components/visualization/TrendHeatmap.tsx
+++ b/website/src/components/visualization/TrendHeatmap.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
+import { clickableProps } from '@/lib/a11y';
 import type { ApiTrend } from '@/lib/api';
 
 interface TrendHeatmapProps {
@@ -139,13 +140,18 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
                   animate={{ scale: 1 }}
                   transition={{ delay: rowIdx * 0.05 + cellIdx * 0.02 }}
                   className={`
-                    flex-1 h-6 m-0.5 rounded cursor-pointer transition-all
+                    flex-1 h-6 m-0.5 rounded transition-all
                     ${getHeatColor(cell.value)}
-                    ${cell.trends.length > 0 ? 'hover:ring-2 hover:ring-[#00ffff]' : ''}
+                    ${cell.trends.length > 0 ? 'cursor-pointer hover:ring-2 hover:ring-[#00ffff]' : ''}
                   `}
                   onMouseEnter={() => setHoveredCell(cell)}
                   onMouseLeave={() => setHoveredCell(null)}
-                  onClick={() => cell.trends.length > 0 && onCellClick?.(cell.category, cell.day)}
+                  {...(cell.trends.length > 0
+                    ? clickableProps(
+                        () => onCellClick?.(cell.category, cell.day),
+                        `${cell.category} - ${cell.day}`
+                      )
+                    : {})}
                 >
                   {cell.trends.length > 0 && (
                     <div className="w-full h-full flex items-center justify-center text-[10px] font-bold text-black/70">


### PR DESCRIPTION
## Summary
Completes the keyboard-accessibility sweep started in [#2873](https://github.com/MosslandOpenDevs/agentic-orchestrator/pull/2873). Every clickable card in the app is now operable by keyboard and announced to screen readers — no remaining mouse-only `<div>` buttons.

Applies the shared `clickableProps()` helper (`role=button`, `tabIndex`, Enter/Space, `aria-label`) to the remaining secondary surfaces:
- `system`, `projects`, `transparency/{signals,debates}` cards
- `details/PipelineDetail`
- `visualization/{IdeaComparison, IdeaNetwork, SignalLineage (×4), TrendHeatmap}`

Conditionally-interactive nodes (SignalLineage, TrendHeatmap) get button semantics + `cursor-pointer` **only when actionable**. Real `<button>`/`<a>`/`<select>`/`<summary>` controls and hover/stopPropagation handlers were left untouched (`LiveDebateViewer` needed no changes — all its interactives are native controls).

## How it was done
Fanned out one agent per file (10 files) to apply the helper, then verified centrally — not trusting the agents' concurrent self-builds.

## Testing
- Single clean `npm run build` ✓ — all 14 routes compile + static-generate.
- `eslint` on every changed file: **no new errors** (pre-existing `any`/react-hooks-purity findings unchanged, confirmed via baseline).
- Conversion diffs spot-checked for correctness (conditional spreads, labels, cursor toggles).

This closes the follow-up noted in #2873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)