### PR TITLE
perf(api): DB-level pagination + drop N+1 message-count + adapter logging (Batch B)

### DIFF
--- a/src/agentic_orchestrator/adapters/coingecko.py
+++ b/src/agentic_orchestrator/adapters/coingecko.py
@@ -9,6 +9,7 @@ Collects market signals from Coingecko API:
 """
 
 import asyncio
+import logging
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -16,6 +17,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class CoingeckoAdapter(BaseAdapter):
@@ -206,7 +209,7 @@ class CoingeckoAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching trending: {e}")
+            logger.warning(f"Error fetching trending: {e}")
 
         return signals
 
@@ -327,7 +330,7 @@ class CoingeckoAdapter(BaseAdapter):
                             signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching top movers: {e}")
+            logger.warning(f"Error fetching top movers: {e}")
 
         return signals
 
@@ -392,7 +395,7 @@ class CoingeckoAdapter(BaseAdapter):
                     signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching global stats: {e}")
+            logger.warning(f"Error fetching global stats: {e}")
 
         return signals
 
@@ -451,7 +454,7 @@ class CoingeckoAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching tracked coins: {e}")
+            logger.warning(f"Error fetching tracked coins: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/discord.py
+++ b/src/agentic_orchestrator/adapters/discord.py
@@ -8,6 +8,7 @@ Collects signals from Discord servers via:
 """
 
 import asyncio
+import logging
 import os
 import time
 from datetime import datetime, timedelta
@@ -16,6 +17,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class DiscordAdapter(BaseAdapter):
@@ -226,7 +229,7 @@ class DiscordAdapter(BaseAdapter):
                         await asyncio.sleep(0.5)
 
                 except Exception as e:
-                    print(f"Error fetching from {server['name']}: {e}")
+                    logger.warning(f"Error fetching from {server['name']}: {e}")
 
         return signals
 
@@ -288,7 +291,7 @@ class DiscordAdapter(BaseAdapter):
                     await asyncio.sleep(1)
 
         except Exception as e:
-            print(f"Error fetching public Discord data: {e}")
+            logger.warning(f"Error fetching public Discord data: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/farcaster.py
+++ b/src/agentic_orchestrator/adapters/farcaster.py
@@ -8,6 +8,7 @@ Collects signals from Farcaster (decentralized social network) via:
 """
 
 import asyncio
+import logging
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -15,6 +16,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class FarcasterAdapter(BaseAdapter):
@@ -141,7 +144,7 @@ class FarcasterAdapter(BaseAdapter):
                     return response.json()
 
         except Exception as e:
-            print(f"Neynar API error: {e}")
+            logger.warning(f"Neynar API error: {e}")
 
         return None
 
@@ -177,7 +180,7 @@ class FarcasterAdapter(BaseAdapter):
                                 signals.append(signal)
 
             except Exception as e:
-                print(f"Warpcast API error: {e}")
+                logger.warning(f"Warpcast API error: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/github_events.py
+++ b/src/agentic_orchestrator/adapters/github_events.py
@@ -8,6 +8,7 @@ Collects signals from GitHub:
 """
 
 import asyncio
+import logging
 import os
 import time
 from datetime import datetime, timedelta
@@ -16,6 +17,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class GitHubEventsAdapter(BaseAdapter):
@@ -164,7 +167,7 @@ class GitHubEventsAdapter(BaseAdapter):
                     signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching trending repos: {e}")
+            logger.warning(f"Error fetching trending repos: {e}")
 
         return signals
 
@@ -229,7 +232,7 @@ class GitHubEventsAdapter(BaseAdapter):
                     signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching releases for {repo}: {e}")
+            logger.warning(f"Error fetching releases for {repo}: {e}")
 
         return signals
 
@@ -292,7 +295,7 @@ class GitHubEventsAdapter(BaseAdapter):
                     await asyncio.sleep(0.5)
 
                 except Exception as e:
-                    print(f"Error fetching topic {topic}: {e}")
+                    logger.warning(f"Error fetching topic {topic}: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/lens.py
+++ b/src/agentic_orchestrator/adapters/lens.py
@@ -5,12 +5,15 @@ Collects signals from Lens Protocol (Web3 social network) via GraphQL API.
 """
 
 import asyncio
+import logging
 import time
 from typing import Any, Dict, List, Optional
 
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class LensAdapter(BaseAdapter):
@@ -112,7 +115,7 @@ class LensAdapter(BaseAdapter):
                     return response.json()
 
         except Exception as e:
-            print(f"Lens GraphQL error: {e}")
+            logger.warning(f"Lens GraphQL error: {e}")
 
         return None
 

--- a/src/agentic_orchestrator/adapters/news.py
+++ b/src/agentic_orchestrator/adapters/news.py
@@ -8,6 +8,7 @@ Collects signals from news APIs:
 """
 
 import asyncio
+import logging
 import os
 import time
 from datetime import datetime, timedelta
@@ -16,6 +17,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class NewsAPIAdapter(BaseAdapter):
@@ -156,7 +159,7 @@ class NewsAPIAdapter(BaseAdapter):
                     await asyncio.sleep(0.5)
 
                 except Exception as e:
-                    print(f"Error fetching NewsAPI for '{query_config['query']}': {e}")
+                    logger.warning(f"Error fetching NewsAPI for '{query_config['query']}': {e}")
 
         return signals
 
@@ -213,7 +216,7 @@ class NewsAPIAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching Cryptopanic: {e}")
+            logger.warning(f"Error fetching Cryptopanic: {e}")
 
         return signals
 
@@ -322,7 +325,7 @@ class NewsAPIAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching Hacker News: {e}")
+            logger.warning(f"Error fetching Hacker News: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/onchain.py
+++ b/src/agentic_orchestrator/adapters/onchain.py
@@ -9,6 +9,7 @@ Collects signals from blockchain data:
 """
 
 import asyncio
+import logging
 import os
 import time
 from typing import Any, Dict, List, Optional
@@ -16,6 +17,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class OnChainAdapter(BaseAdapter):
@@ -193,7 +196,7 @@ class OnChainAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching DeFi TVL: {e}")
+            logger.warning(f"Error fetching DeFi TVL: {e}")
 
         return signals
 
@@ -232,7 +235,7 @@ class OnChainAdapter(BaseAdapter):
                     signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching chain stats: {e}")
+            logger.warning(f"Error fetching chain stats: {e}")
 
         return signals
 
@@ -274,7 +277,7 @@ class OnChainAdapter(BaseAdapter):
                     signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching protocol updates: {e}")
+            logger.warning(f"Error fetching protocol updates: {e}")
 
         return signals
 
@@ -328,7 +331,7 @@ class OnChainAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching DEX volume: {e}")
+            logger.warning(f"Error fetching DEX volume: {e}")
 
         return signals
 
@@ -390,7 +393,7 @@ class OnChainAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching whale transactions: {e}")
+            logger.warning(f"Error fetching whale transactions: {e}")
 
         return signals
 
@@ -419,7 +422,7 @@ class OnChainAdapter(BaseAdapter):
                 # track specific whale addresses or use a service that aggregates this.
 
         except Exception as e:
-            print(f"Error fetching from explorers: {e}")
+            logger.warning(f"Error fetching from explorers: {e}")
 
         return signals
 
@@ -509,7 +512,7 @@ class OnChainAdapter(BaseAdapter):
                             signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching stablecoin data: {e}")
+            logger.warning(f"Error fetching stablecoin data: {e}")
 
         return signals
 
@@ -559,7 +562,7 @@ class OnChainAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error fetching gas prices: {e}")
+            logger.warning(f"Error fetching gas prices: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/rss.py
+++ b/src/agentic_orchestrator/adapters/rss.py
@@ -10,6 +10,7 @@ Collects signals from RSS feeds across multiple categories:
 """
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -19,6 +20,8 @@ import feedparser
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -194,7 +197,7 @@ class RSSAdapter(BaseAdapter):
 
         except Exception as e:
             # Log error but don't fail the entire adapter
-            print(f"Error fetching feed {feed.name}: {e}")
+            logger.warning(f"Error fetching feed {feed.name}: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/adapters/social.py
+++ b/src/agentic_orchestrator/adapters/social.py
@@ -8,6 +8,7 @@ Collects signals from social platforms:
 """
 
 import asyncio
+import logging
 import os
 import time
 from datetime import datetime, timedelta
@@ -17,6 +18,8 @@ import feedparser
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class SocialMediaAdapter(BaseAdapter):
@@ -143,7 +146,7 @@ class SocialMediaAdapter(BaseAdapter):
                 return self._reddit_token
 
         except Exception as e:
-            print(f"Error getting Reddit token: {e}")
+            logger.warning(f"Error getting Reddit token: {e}")
             return None
 
     async def _fetch_reddit(self) -> List[SignalData]:
@@ -217,7 +220,7 @@ class SocialMediaAdapter(BaseAdapter):
                     await asyncio.sleep(0.5)
 
                 except Exception as e:
-                    print(f"Error fetching r/{subreddit}: {e}")
+                    logger.warning(f"Error fetching r/{subreddit}: {e}")
 
         return signals
 
@@ -261,7 +264,7 @@ class SocialMediaAdapter(BaseAdapter):
                     await asyncio.sleep(1)  # Be nice to Reddit
 
                 except Exception as e:
-                    print(f"Error fetching r/{subreddit} RSS: {e}")
+                    logger.warning(f"Error fetching r/{subreddit} RSS: {e}")
 
         return signals
 
@@ -300,7 +303,7 @@ class SocialMediaAdapter(BaseAdapter):
                             break  # Success, move to next account
 
                     except Exception as e:
-                        print(f"Error fetching @{account} from {instance}: {e}")
+                        logger.warning(f"Error fetching @{account} from {instance}: {e}")
                         continue
 
                 await asyncio.sleep(1)

--- a/src/agentic_orchestrator/adapters/twitter.py
+++ b/src/agentic_orchestrator/adapters/twitter.py
@@ -6,6 +6,7 @@ for improved reliability and redundancy.
 """
 
 import asyncio
+import logging
 import os
 import random
 import time
@@ -16,6 +17,8 @@ import feedparser
 import httpx
 
 from .base import AdapterConfig, AdapterResult, BaseAdapter, SignalData
+
+logger = logging.getLogger(__name__)
 
 
 class TwitterAdapter(BaseAdapter):
@@ -230,7 +233,7 @@ class TwitterAdapter(BaseAdapter):
                             break  # Success, move to next account
 
                     except Exception as e:
-                        print(f"Error fetching @{account} from {instance}: {e}")
+                        logger.warning(f"Error fetching @{account} from {instance}: {e}")
                         continue
 
                 # Rate limiting
@@ -291,7 +294,7 @@ class TwitterAdapter(BaseAdapter):
                         signals.append(signal)
 
         except Exception as e:
-            print(f"Error searching Twitter API: {e}")
+            logger.warning(f"Error searching Twitter API: {e}")
 
         return signals
 

--- a/src/agentic_orchestrator/api/main.py
+++ b/src/agentic_orchestrator/api/main.py
@@ -306,12 +306,12 @@ async def get_debates(
 
     paginated = sessions
 
-    # Build response with message counts
-    debates = []
-    for debate in paginated:
-        debate_dict = debate.to_dict()
-        debate_dict["message_count"] = len(debate.messages) if debate.messages else 0
-        debates.append(debate_dict)
+    # Build response with message counts fetched in a single bulk query
+    # (avoids an N+1 that would lazy-load every session's full message list).
+    message_counts = repo.count_messages_for_sessions([s.id for s in paginated])
+    debates = [
+        debate.to_dict(message_count=message_counts.get(debate.id, 0)) for debate in paginated
+    ]
 
     return {
         "debates": debates,
@@ -336,7 +336,7 @@ async def get_debate_detail(
     messages = repo.get_session_messages(session_id)
 
     return {
-        "debate": debate.to_dict(),
+        "debate": debate.to_dict(message_count=len(messages)),
         "messages": [m.to_dict() for m in messages],
         "message_count": len(messages),
     }
@@ -353,21 +353,20 @@ async def get_trends(
     """Get trend analysis results."""
     repo = TrendRepository(session)
 
+    # DB-level pagination: push offset/limit into the query instead of fetching
+    # `limit + offset` rows and slicing in memory.
     if category:
-        trends = repo.get_by_category(category, limit=limit + offset)
-        total = len(trends)
+        trends = repo.get_by_category(category, limit=limit, offset=offset)
+        total = repo.count_by_category(category)
     elif period == "all":
-        trends = repo.get_all(limit=limit + offset)
+        trends = repo.get_all(limit=limit, offset=offset)
         total = repo.count_all()
     else:
-        trends = repo.get_latest(period=period, limit=limit + offset)
-        total = len(trends)
-
-    # Apply offset
-    paginated = trends[offset : offset + limit]
+        trends = repo.get_latest(period=period, limit=limit, offset=offset)
+        total = repo.count_by_period(period)
 
     return {
-        "trends": [t.to_dict() for t in paginated],
+        "trends": [t.to_dict() for t in trends],
         "total": total,
         "limit": limit,
         "offset": offset,
@@ -389,16 +388,14 @@ async def get_ideas(
     status_counts = repo.count_by_status()
 
     if status:
-        ideas = repo.get_by_status(status, limit=limit + offset)
+        ideas = repo.get_by_status(status, limit=limit, offset=offset)
         total = status_counts.get(status, 0)
     else:
         ideas = repo.get_all(limit=limit, offset=offset)
         total = repo.count_all()
 
-    paginated = ideas if status is None else ideas[offset : offset + limit]
-
     return {
-        "ideas": [i.to_dict() for i in paginated],
+        "ideas": [i.to_dict() for i in ideas],
         "total": total,
         "limit": limit,
         "offset": offset,

--- a/src/agentic_orchestrator/api/main.py
+++ b/src/agentic_orchestrator/api/main.py
@@ -433,7 +433,7 @@ async def get_idea_detail(
         source_debate = debate_repo.get_session_by_id(source_debate_id)
         if source_debate:
             messages = debate_repo.get_session_messages(source_debate_id)
-            debate_dict = source_debate.to_dict()
+            debate_dict = source_debate.to_dict(message_count=len(messages))
             debate_dict["messages"] = [m.to_dict() for m in messages]
             debates.append(debate_dict)
             seen_ids.add(source_debate_id)
@@ -443,7 +443,7 @@ async def get_idea_detail(
     for d in linked_debates:
         if d.id not in seen_ids:
             messages = debate_repo.get_session_messages(d.id)
-            debate_dict = d.to_dict()
+            debate_dict = d.to_dict(message_count=len(messages))
             debate_dict["messages"] = [m.to_dict() for m in messages]
             debates.append(debate_dict)
             seen_ids.add(d.id)

--- a/src/agentic_orchestrator/db/models.py
+++ b/src/agentic_orchestrator/db/models.py
@@ -8,7 +8,7 @@ API usage tracking, and system logs.
 import enum
 import uuid
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from sqlalchemy import (
     JSON,
@@ -282,7 +282,14 @@ class DebateSession(Base):
         "DebateMessage", back_populates="session", order_by="DebateMessage.created_at"
     )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, message_count: Optional[int] = None) -> Dict[str, Any]:
+        """Serialize the session.
+
+        ``message_count`` should be supplied by the caller (e.g. via a bulk
+        ``COUNT ... GROUP BY`` query) so that serializing a list of sessions does
+        not lazy-load every session's messages just to count them (an N+1). When
+        omitted it defaults to 0 rather than triggering a relationship load.
+        """
         return {
             "id": self.id,
             "idea_id": self.idea_id,
@@ -301,7 +308,7 @@ class DebateSession(Base):
             "total_cost": self.total_cost,
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
-            "message_count": len(self.messages) if self.messages else 0,
+            "message_count": message_count if message_count is not None else 0,
         }
 
 

--- a/src/agentic_orchestrator/db/repositories.py
+++ b/src/agentic_orchestrator/db/repositories.py
@@ -177,31 +177,34 @@ class TrendRepository(BaseRepository):
         """Get trend by ID."""
         return self.session.query(Trend).filter(Trend.id == trend_id).first()
 
-    def get_latest(self, period: str = "24h", limit: int = 10) -> List[Trend]:
+    def get_latest(self, period: str = "24h", limit: int = 10, offset: int = 0) -> List[Trend]:
         """Get latest trends for a period."""
         return (
             self.session.query(Trend)
             .filter(Trend.period == period)
             .order_by(desc(Trend.analyzed_at), desc(Trend.score))
+            .offset(offset)
             .limit(limit)
             .all()
         )
 
-    def get_by_category(self, category: str, limit: int = 10) -> List[Trend]:
+    def get_by_category(self, category: str, limit: int = 10, offset: int = 0) -> List[Trend]:
         """Get trends by category."""
         return (
             self.session.query(Trend)
             .filter(Trend.category == category)
             .order_by(desc(Trend.score))
+            .offset(offset)
             .limit(limit)
             .all()
         )
 
-    def get_all(self, limit: int = 100) -> List[Trend]:
+    def get_all(self, limit: int = 100, offset: int = 0) -> List[Trend]:
         """Get all trends regardless of period."""
         return (
             self.session.query(Trend)
             .order_by(desc(Trend.analyzed_at), desc(Trend.score))
+            .offset(offset)
             .limit(limit)
             .all()
         )
@@ -209,6 +212,17 @@ class TrendRepository(BaseRepository):
     def count_all(self) -> int:
         """Get total count of all trends."""
         return self.session.query(func.count(Trend.id)).scalar() or 0
+
+    def count_by_category(self, category: str) -> int:
+        """Get total count of trends in a category."""
+        return (
+            self.session.query(func.count(Trend.id)).filter(Trend.category == category).scalar()
+            or 0
+        )
+
+    def count_by_period(self, period: str) -> int:
+        """Get total count of trends for a period."""
+        return self.session.query(func.count(Trend.id)).filter(Trend.period == period).scalar() or 0
 
     def delete_older_than(self, days: int) -> int:
         """Delete trends older than specified days."""
@@ -232,12 +246,13 @@ class IdeaRepository(BaseRepository):
         """Get idea by ID."""
         return self.session.query(Idea).filter(Idea.id == idea_id).first()
 
-    def get_by_status(self, status: str, limit: int = 50) -> List[Idea]:
+    def get_by_status(self, status: str, limit: int = 50, offset: int = 0) -> List[Idea]:
         """Get ideas by status."""
         return (
             self.session.query(Idea)
             .filter(Idea.status == status)
             .order_by(desc(Idea.created_at))
+            .offset(offset)
             .limit(limit)
             .all()
         )
@@ -408,6 +423,22 @@ class DebateRepository(BaseRepository):
         if phase:
             query = query.filter(DebateSession.phase == phase)
         return query.scalar() or 0
+
+    def count_messages_for_sessions(self, session_ids: List[str]) -> Dict[str, int]:
+        """Return {session_id: message_count} for the given sessions in one query.
+
+        Lets list endpoints avoid an N+1 (loading every session's messages just
+        to count them). Sessions with no messages are absent from the result.
+        """
+        if not session_ids:
+            return {}
+        rows = (
+            self.session.query(DebateMessage.session_id, func.count(DebateMessage.id))
+            .filter(DebateMessage.session_id.in_(session_ids))
+            .group_by(DebateMessage.session_id)
+            .all()
+        )
+        return dict(rows)
 
     def update_session(self, session_id: str, **kwargs) -> Optional[DebateSession]:
         """Update debate session fields."""

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,163 @@
+"""Tests for DB-level pagination and the N+1 message-count fix (PR2 backend hardening).
+
+These cover the behavior changed in the backend-hardening pass:
+- /trends and /ideas?status= paginate at the SQL layer (offset/limit pushed into
+  the query) and report `total` from a COUNT, not the page size.
+- DebateSession message counts come from a single bulk COUNT...GROUP BY query
+  instead of lazy-loading each session's messages (the former N+1).
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from agentic_orchestrator.api.main import app, get_session
+from agentic_orchestrator.db.models import Base, DebateMessage, DebateSession, Idea, Trend
+from agentic_orchestrator.db.repositories import DebateRepository
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Local = sessionmaker(autocommit=False, autoflush=False, bind=engine)  # noqa: N806
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_session():
+        s = Local()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    app.dependency_overrides[get_session] = override_get_session
+    s = Local()
+    yield s
+    s.close()
+    Base.metadata.drop_all(bind=engine)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(db):
+    return TestClient(app)
+
+
+def _add_trends(db, n, period="24h", category="crypto"):
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    for i in range(n):
+        db.add(
+            Trend(
+                period=period,
+                name=f"Trend {i}",
+                description="d",
+                score=float(i),
+                signal_count=1,
+                category=category,
+                analyzed_at=base + timedelta(minutes=i),
+            )
+        )
+    db.commit()
+
+
+class TestTrendPagination:
+    def test_offset_pages_do_not_overlap(self, client, db):
+        _add_trends(db, 5)
+        page1 = client.get("/trends?period=all&limit=2&offset=0").json()
+        page2 = client.get("/trends?period=all&limit=2&offset=2").json()
+        assert page1["total"] == 5
+        assert page2["total"] == 5
+        assert len(page1["trends"]) == 2
+        assert len(page2["trends"]) == 2
+        names1 = {t["name"] for t in page1["trends"]}
+        names2 = {t["name"] for t in page2["trends"]}
+        assert names1.isdisjoint(names2)
+
+    def test_category_total_is_count_not_page_size(self, client, db):
+        _add_trends(db, 4, category="crypto")
+        _add_trends(db, 1, category="ai")
+        body = client.get("/trends?category=crypto&limit=2&offset=0").json()
+        assert body["total"] == 4  # full category count, not the 2 returned
+        assert len(body["trends"]) == 2
+
+    def test_period_total_is_count(self, client, db):
+        _add_trends(db, 3, period="7d")
+        body = client.get("/trends?period=7d&limit=1&offset=0").json()
+        assert body["total"] == 3
+        assert len(body["trends"]) == 1
+
+
+class TestIdeaStatusPagination:
+    def test_status_offset_slices_at_db_level(self, client, db):
+        for i in range(5):
+            db.add(
+                Idea(
+                    title=f"Idea {i}",
+                    summary="s",
+                    source_type="trend_based",
+                    status="pending",
+                    score=1.0,
+                )
+            )
+        db.commit()
+        page1 = client.get("/ideas?status=pending&limit=2&offset=0").json()
+        page2 = client.get("/ideas?status=pending&limit=2&offset=2").json()
+        assert page1["total"] == 5
+        assert len(page1["ideas"]) == 2
+        ids1 = {i["id"] for i in page1["ideas"]}
+        ids2 = {i["id"] for i in page2["ideas"]}
+        assert ids1.isdisjoint(ids2)
+
+
+class TestMessageCountNoNPlusOne:
+    def _make_sessions(self, db, counts):
+        """Create sessions, each with `counts[i]` messages. Returns the sessions."""
+        sessions = []
+        for _ in counts:
+            s = DebateSession(
+                phase="divergence",
+                round_number=1,
+                max_rounds=3,
+                status="completed",
+            )
+            db.add(s)
+            db.commit()
+            sessions.append(s)
+        for s, c in zip(sessions, counts, strict=True):
+            for _ in range(c):
+                db.add(
+                    DebateMessage(
+                        session_id=s.id,
+                        agent_id="a",
+                        agent_name="A",
+                        message_type="propose",
+                        content="c",
+                    )
+                )
+        db.commit()
+        return sessions
+
+    def test_bulk_count_matches_and_omits_zero(self, db):
+        sessions = self._make_sessions(db, [2, 0, 1])
+        repo = DebateRepository(db)
+        counts = repo.count_messages_for_sessions([s.id for s in sessions])
+        assert counts.get(sessions[0].id) == 2
+        assert sessions[1].id not in counts  # zero-message sessions are absent
+        assert counts.get(sessions[2].id) == 1
+
+    def test_bulk_count_empty_input(self, db):
+        repo = DebateRepository(db)
+        assert repo.count_messages_for_sessions([]) == {}
+
+    def test_debates_endpoint_reports_message_count(self, client, db):
+        sessions = self._make_sessions(db, [3])
+        body = client.get("/debates").json()
+        target = next(d for d in body["debates"] if d["id"] == sessions[0].id)
+        assert target["message_count"] == 3

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -161,3 +161,41 @@ class TestMessageCountNoNPlusOne:
         body = client.get("/debates").json()
         target = next(d for d in body["debates"] if d["id"] == sessions[0].id)
         assert target["message_count"] == 3
+
+    def test_idea_detail_nested_debate_message_count(self, client, db):
+        """Regression: /ideas/{id} serializes nested debates; their message_count
+        must reflect the loaded messages, not default to 0."""
+        idea = Idea(
+            title="Idea with debate",
+            summary="s",
+            source_type="debate",
+            status="promoted",
+            score=8.0,
+        )
+        db.add(idea)
+        db.commit()
+        sess = DebateSession(
+            idea_id=idea.id,
+            phase="planning",
+            round_number=1,
+            max_rounds=3,
+            status="completed",
+        )
+        db.add(sess)
+        db.commit()
+        for _ in range(2):
+            db.add(
+                DebateMessage(
+                    session_id=sess.id,
+                    agent_id="a",
+                    agent_name="A",
+                    message_type="propose",
+                    content="c",
+                )
+            )
+        db.commit()
+        body = client.get(f"/ideas/{idea.id}").json()
+        assert len(body["debates"]) >= 1
+        nested = body["debates"][0]
+        assert nested["message_count"] == 2
+        assert len(nested["messages"]) == 2


### PR DESCRIPTION
## Summary — Backend hardening (Batch B)
Addresses the verified high/medium backend findings from the codebase health assessment.

### 1. DB-level pagination (`/trends`, `/ideas?status=`)
Both endpoints fetched `limit + offset` rows and sliced in memory. Now offset/limit are pushed into the SQL query, and `total` comes from a `COUNT` instead of the page size.
- `TrendRepository`: added `offset` to `get_latest`/`get_by_category`/`get_all`, and new `count_by_category` / `count_by_period`.
- `IdeaRepository.get_by_status`: added `offset`.

### 2. Removed N+1 in `/debates`
`DebateSession.to_dict()` called `len(self.messages)`, lazy-loading every session's full message list just to count — one extra query (and full row fetch) per session in the list. Now:
- `DebateRepository.count_messages_for_sessions()` returns all counts in one `COUNT ... GROUP BY`.
- `to_dict(message_count=...)` takes the count from the caller and never triggers a relationship load.

### 3. Adapter logging
10 signal adapters used `print()` for fetch errors. They now use a module `logger` so errors flow through the logging infrastructure (consistent with the rest of the codebase).

## Tests
- `tests/test_pagination.py` (7 new): offset pages don't overlap, `total` is a COUNT (not page size) for category/period, idea-status paging, the bulk message-count (incl. empty input + zero-message sessions), and `/debates` `message_count`.
- Local gate: **ruff + black clean, 196 tests pass**.

## Notes
- Pure backend; no schema change, no API contract change (same response shapes).
- Dependency floors (anthropic/fastapi/uvicorn) were already modernized in earlier PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)