### PR TITLE
a11y(web): visible keyboard focus on idea graph nodes + aria-pressed on comparison tiles

### DIFF
--- a/website/src/components/visualization/IdeaComparison.tsx
+++ b/website/src/components/visualization/IdeaComparison.tsx
@@ -112,6 +112,7 @@ export function IdeaComparison({
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
               {...clickableProps(() => toggleSelect(idea.id), idea.title)}
+              aria-pressed={isSelected}
               className={`
                 p-2 rounded border cursor-pointer transition-colors
                 ${isSelected

--- a/website/src/components/visualization/IdeaNetwork.tsx
+++ b/website/src/components/visualization/IdeaNetwork.tsx
@@ -181,6 +181,8 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
                     className="cursor-pointer"
                     onMouseEnter={() => setHoveredNode(node.id)}
                     onMouseLeave={() => setHoveredNode(null)}
+                    onFocus={() => setHoveredNode(node.id)}
+                    onBlur={() => setHoveredNode(null)}
                     {...clickableProps(() => handleNodeClick(node.id), node.title)}
                   />
 


### PR DESCRIPTION
Follow-up to #2874, which made the remaining secondary clickable surfaces keyboard-operable. While adversarially reviewing that area, two gaps surfaced that #2874 did **not** cover. This PR closes them (+3 lines, no behavior change for mouse users).

## Changes

### 1. `IdeaNetwork` — visible keyboard focus on SVG graph nodes (WCAG 2.4.7)
The graph nodes are `<motion.circle>` elements made focusable via `clickableProps` (`role=button`, `tabIndex=0`). However, **CSS `outline` is a documented no-op on SVG geometry (circle/rect/path) in Blink/WebKit** — only Firefox paints it. The app's only focus style is the global `:focus-visible { outline: 2px solid }`, and the node's highlight `stroke` was driven solely by mouse hover/click state. Result: a keyboard-focused node showed **no visible focus indicator** in Chrome/Edge/Safari.

Fix: wire `onFocus`/`onBlur` to the existing `hoveredNode` state, so focusing a node reuses the same white-stroke + scale-up highlight as hover — reliable cross-browser, no new CSS.

### 2. `IdeaComparison` — `aria-pressed` on selectable tiles
The idea-selection tiles are toggle buttons (`clickableProps` over a `motion.div`) but did not expose their selected state. Added `aria-pressed={isSelected}` so screen readers announce selection.

## Verification
- `next build` green (all 14 routes), TypeScript clean.
- No new ESLint problems (the pre-existing `Math.random` purity error in the force-directed layout calc is unchanged and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)