### PR TITLE
a11y(web): focus management for AdapterDetailModal

### DIFF
--- a/website/src/components/AdapterDetailModal.tsx
+++ b/website/src/components/AdapterDetailModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
 import type { AdapterInfo } from '@/lib/types';
@@ -20,6 +20,8 @@ export function AdapterDetailModal({
 }: AdapterDetailModalProps) {
   const { locale } = useI18n();
   const [selectedAdapter, setSelectedAdapter] = useState<AdapterInfo | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = 'adapter-detail-modal-title';
 
   // Auto-select first adapter when adapters load
   useEffect(() => {
@@ -35,16 +37,59 @@ export function AdapterDetailModal({
     }
   }, [isOpen]);
 
-  // Close on escape key
+  // Escape to close + Tab focus trap within the dialog.
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusable = Array.from(
+          dialogRef.current.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+          )
+        ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+        if (focusable.length === 0) {
+          event.preventDefault();
+          dialogRef.current.focus();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+        const insideDialog = dialogRef.current.contains(active);
+        if (event.shiftKey) {
+          if (!insideDialog || active === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (!insideDialog || active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [onClose]
+  );
+
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    if (!isOpen) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  // Lock background scroll, move focus into the dialog, and restore focus on close.
+  useEffect(() => {
+    if (!isOpen) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    document.body.style.overflow = 'hidden';
+    dialogRef.current?.focus();
+    return () => {
+      document.body.style.overflow = '';
+      previouslyFocused?.focus?.();
     };
-    if (isOpen) {
-      window.addEventListener('keydown', handleEscape);
-    }
-    return () => window.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   const categoryColors: Record<string, string> = {
     news: 'text-[#f1fa8c]',
@@ -77,6 +122,11 @@ export function AdapterDetailModal({
 
           {/* Modal */}
           <motion.div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            tabIndex={-1}
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
@@ -86,13 +136,14 @@ export function AdapterDetailModal({
             <div className="flex items-center justify-between p-4 border-b border-[#30363d]">
               <div className="flex items-center gap-3">
                 <span className="text-[#bd93f9]">◈</span>
-                <h2 className="text-lg font-mono text-[#c0c0c0]">
+                <h2 id={titleId} className="text-lg font-mono text-[#c0c0c0]">
                   {locale === 'ko' ? '시그널 어댑터 상세 정보' : 'Signal Adapters Detail'}
                 </h2>
                 <span className="tag tag-cyan">{adapters.length} adapters</span>
               </div>
               <button
                 onClick={onClose}
+                aria-label={locale === 'ko' ? '닫기' : 'Close'}
                 className="text-[#8b949e] hover:text-[#c0c0c0] transition-colors text-xl"
               >
                 ×


### PR DESCRIPTION
## Summary
A holistic UI/UX re-review found the frontend is already in good a11y shape after the earlier overhaul (#2873/#2874): CSS + framer-motion both honor `prefers-reduced-motion` (`<MotionConfig reducedMotion="user">`), the hamburger button has full ARIA, and `TerminalModal` already implements a complete focus trap. The **one remaining gap** was `AdapterDetailModal`, which only handled Escape.

This brings `AdapterDetailModal` to the same standard as `TerminalModal`:
- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` (the heading), `tabIndex={-1}`
- a **Tab focus trap** that keeps focus inside the dialog and wraps at the edges
- **focus moved into the dialog on open**, restored to the opener on close
- **background scroll lock** while open
- `aria-label` on the bare `×` close button

## Verification (frontend has no CI job — `npm run build` is the deploy gate)
- `npm run build` ✅ passes.
- Verified live in the browser preview: opening the modal yields `role=dialog` with `aria-modal`/`aria-labelledby` resolving to "Signal Adapters Detail", **focus enters the dialog**, body scroll locks, **Escape closes** it (and scroll unlocks), close button is labeled, and there are **no console errors**.

## Notes
- Pure a11y/semantics change — no visual redesign, no behavior change for mouse users.
- Two pre-existing `react-hooks/set-state-in-effect` eslint findings on the adapter auto-select/reset effects are **not introduced here** and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)