### PR TITLE
fix(web): derive adapter selection (no set-state effects) + fresh demo timestamps

### DIFF
--- a/website/src/components/AdapterDetailModal.tsx
+++ b/website/src/components/AdapterDetailModal.tsx
@@ -30,11 +30,19 @@ export function AdapterDetailModal({
   const selectedAdapter =
     adapters.find((a) => a.name === selectedName) ?? adapters[0] ?? null;
 
+  // Clear the selection as part of closing (replaces the old reset-on-close
+  // effect) so the next open starts on the first adapter again. Event-based, so
+  // it doesn't re-introduce a setState-in-effect.
+  const handleClose = useCallback(() => {
+    setSelectedName(null);
+    onClose();
+  }, [onClose]);
+
   // Escape to close + Tab focus trap within the dialog.
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        onClose();
+        handleClose();
         return;
       }
       if (event.key === 'Tab' && dialogRef.current) {
@@ -63,7 +71,7 @@ export function AdapterDetailModal({
         }
       }
     },
-    [onClose]
+    [handleClose]
   );
 
   useEffect(() => {
@@ -109,7 +117,7 @@ export function AdapterDetailModal({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            onClick={onClose}
+            onClick={handleClose}
             className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50"
           />
 
@@ -135,7 +143,7 @@ export function AdapterDetailModal({
                 <span className="tag tag-cyan">{adapters.length} adapters</span>
               </div>
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 aria-label={locale === 'ko' ? '닫기' : 'Close'}
                 className="text-[#8b949e] hover:text-[#c0c0c0] transition-colors text-xl"
               >

--- a/website/src/components/AdapterDetailModal.tsx
+++ b/website/src/components/AdapterDetailModal.tsx
@@ -19,23 +19,16 @@ export function AdapterDetailModal({
   isLoading,
 }: AdapterDetailModalProps) {
   const { locale } = useI18n();
-  const [selectedAdapter, setSelectedAdapter] = useState<AdapterInfo | null>(null);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const titleId = 'adapter-detail-modal-title';
 
-  // Auto-select first adapter when adapters load
-  useEffect(() => {
-    if (adapters.length > 0 && !selectedAdapter) {
-      setSelectedAdapter(adapters[0]);
-    }
-  }, [adapters, selectedAdapter]);
-
-  // Reset selection when modal closes
-  useEffect(() => {
-    if (!isOpen) {
-      setSelectedAdapter(null);
-    }
-  }, [isOpen]);
+  // Derive the selected adapter rather than syncing it through effects (which
+  // tripped react-hooks/set-state-in-effect): use the explicitly-selected
+  // adapter, otherwise fall back to the first. A stale name (adapter no longer
+  // in the list) also falls back gracefully.
+  const selectedAdapter =
+    adapters.find((a) => a.name === selectedName) ?? adapters[0] ?? null;
 
   // Escape to close + Tab focus trap within the dialog.
   const handleKeyDown = useCallback(
@@ -168,7 +161,7 @@ export function AdapterDetailModal({
                     {adapters.map((adapter) => (
                       <button
                         key={adapter.name}
-                        onClick={() => setSelectedAdapter(adapter)}
+                        onClick={() => setSelectedName(adapter.name)}
                         className={`w-full p-3 text-left hover:bg-[#21262d]/50 transition-colors ${
                           selectedAdapter?.name === adapter.name ? 'bg-[#21262d]' : ''
                         }`}

--- a/website/src/components/SystemStatus.tsx
+++ b/website/src/components/SystemStatus.tsx
@@ -51,10 +51,10 @@ export function SystemStatus({ lastRun, nextRun }: SystemStatusProps) {
         {/* Last Run */}
         <div className="flex items-center gap-2">
           <span className="text-[#8b949e] text-xs">last_run:</span>
-          <span className="text-[#c0c0c0] text-xs">
+          <span className="text-[#c0c0c0] text-xs" suppressHydrationWarning>
             {formatDistanceToNow(lastRunDate, { addSuffix: true, locale: dateLocale })}
           </span>
-          <span className="text-[#8b949e] text-[10px]">
+          <span className="text-[#8b949e] text-[10px]" suppressHydrationWarning>
             ({format(lastRunDate, 'HH:mm:ss')})
           </span>
         </div>
@@ -64,7 +64,7 @@ export function SystemStatus({ lastRun, nextRun }: SystemStatusProps) {
         {/* Next Run */}
         <div className="flex items-center gap-2">
           <span className="text-[#8b949e] text-xs">next_run:</span>
-          <span className="text-[#00ffff] text-xs">
+          <span className="text-[#00ffff] text-xs" suppressHydrationWarning>
             {nextRunLabel}
           </span>
         </div>

--- a/website/src/data/mock.ts
+++ b/website/src/data/mock.ts
@@ -6,8 +6,12 @@ export const mockStats: SystemStats = {
   plansRejected: 2,
   inDevelopment: 0,
   trendsAnalyzed: 254,
-  lastRun: '2026-01-04T23:00:00Z',
-  nextRun: '2026-01-05T23:00:00Z',
+  // Computed relative to load time so the demo dashboard never reads as
+  // "months ago" when the backend is unreachable (placeholders the real API
+  // overwrites). The dependent UI uses suppressHydrationWarning because the
+  // rendered relative time is inherently client-clock dependent.
+  lastRun: new Date(Date.now() - 6 * 60_000).toISOString(),
+  nextRun: new Date(Date.now() + 24 * 60_000).toISOString(),
 };
 
 export const mockActivity: ActivityItem[] = [


### PR DESCRIPTION
## Summary
Two small, self-contained frontend cleanups.

### 1. `AdapterDetailModal` — remove the 2 `set-state-in-effect` lint errors
The component synced `selectedAdapter` through two effects (`setState` in `useEffect`), which ESLint's `react-hooks/set-state-in-effect` flagged. Replaced with a **derived value**:
```ts
const selectedAdapter = adapters.find(a => a.name === selectedName) ?? adapters[0] ?? null;
```
- "auto-select first adapter" → handled by the `?? adapters[0]` fallback (no effect, no flicker).
- "reset on close" → no longer needed: a stale/removed `selectedName` falls back gracefully.
- The dialog's focus trap / ARIA (from #2878) is untouched.

### 2. Demo dashboard timestamps — stop reading "6 months ago"
`mockStats.lastRun/nextRun` were hardcoded to `2026-01`, so the **offline fallback** showed "6 months ago". Now computed relative to load time (~6 min ago / ~24 min out). The time-relative spans in `SystemStatus` get `suppressHydrationWarning` because their rendered value is inherently client-clock dependent — this avoids a static-prerender hydration mismatch **without** a `setState` mounted-gate (which would re-introduce the lint error).

## Verification (frontend has no CI job — build + browser is the gate)
- **ESLint clean** — both `set-state-in-effect` errors resolved; `npm run build` passes.
- Browser preview: dashboard shows **"last_run: 7 minutes ago", "next_run: in 23 minutes"** (no more "months ago"); **zero console errors** (no hydration mismatch). The adapter modal opens, **traps focus** (a11y intact), renders the empty-state gracefully with 0 adapters, and **closes on Escape**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)