### PR TITLE
chore(web): clear all 30 frontend ESLint problems + de-stale a demo line

### DIFF
--- a/website/src/app/debates/page.tsx
+++ b/website/src/app/debates/page.tsx
@@ -16,16 +16,19 @@ const IDLE_POLL_INTERVAL = 30000;
 export default function DebatesPage() {
   const { t, locale } = useI18n();
   const { openModal } = useModal();
-  const [debates, setDebates] = useState<ApiDebate[]>([]);
-  const [loading, setLoading] = useState(true);
+  // `null` means "not loaded yet" so we can derive `loading` during render
+  // instead of syncing a separate loading flag via an effect.
+  const [debates, setDebates] = useState<ApiDebate[] | null>(null);
   const [filter, setFilter] = useState<{ status?: string; phase?: string }>({});
   const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
   const [hasActiveDebate, setHasActiveDebate] = useState(false);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
 
-  const fetchDebates = useCallback(async (showLoading = false) => {
-    if (showLoading) setLoading(true);
+  // Derived render values (no effect needed)
+  const loading = debates === null;
+  const debateList = debates ?? [];
 
+  const fetchDebates = useCallback(async () => {
     const response = await ApiClient.getDebates({
       limit: 50,
       status: filter.status,
@@ -39,29 +42,32 @@ export default function DebatesPage() {
       setHasActiveDebate(active);
       setLastUpdate(new Date());
     }
-    if (showLoading) setLoading(false);
   }, [filter]);
 
-  // Initial fetch
-  useEffect(() => {
-    fetchDebates(true);
-  }, [fetchDebates]);
-
-  // Polling effect
+  // Fetch on mount / filter change and poll for updates. The interval cadence
+  // adapts to whether a debate is currently active. Fetches are scheduled
+  // (immediate kick-off + interval) rather than called synchronously so the
+  // effect body never triggers a synchronous state update.
   useEffect(() => {
     // Clear existing interval
     if (pollingRef.current) {
       clearInterval(pollingRef.current);
     }
 
+    // Kick off an immediate fetch, then poll.
+    const kickoff = setTimeout(() => {
+      fetchDebates();
+    }, 0);
+
     // Set polling interval based on active debates
     const interval = hasActiveDebate ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
 
     pollingRef.current = setInterval(() => {
-      fetchDebates(false);
+      fetchDebates();
     }, interval);
 
     return () => {
+      clearTimeout(kickoff);
       if (pollingRef.current) {
         clearInterval(pollingRef.current);
       }
@@ -238,7 +244,7 @@ export default function DebatesPage() {
         </TerminalWindow>
 
         {/* Debates List */}
-        <TerminalWindow title={`DEBATE_SESSIONS (${debates.length})`}>
+        <TerminalWindow title={`DEBATE_SESSIONS (${debateList.length})`}>
           {loading ? (
             <div className="text-center py-12">
               <div className="text-[#ff6b35] animate-pulse">
@@ -246,7 +252,7 @@ export default function DebatesPage() {
                 <span className="cursor-blink">_</span>
               </div>
             </div>
-          ) : debates.length === 0 ? (
+          ) : debateList.length === 0 ? (
             <div className="text-center py-12">
               <div className="text-4xl mb-4">💬</div>
               <div className="text-[#8b949e] mb-2">{t('debates.noDebates')}</div>
@@ -256,7 +262,7 @@ export default function DebatesPage() {
             </div>
           ) : (
             <div className="space-y-3">
-              {debates.map((debate, idx) => (
+              {debateList.map((debate, idx) => (
                 <motion.div
                   key={debate.id}
                   initial={{ opacity: 0, x: -20 }}

--- a/website/src/app/ideas/page.tsx
+++ b/website/src/app/ideas/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useI18n } from '@/lib/i18n';
 import { ApiClient, type ApiTrend, type ApiIdea, type ApiPlan, type ApiProject } from '@/lib/api';

--- a/website/src/app/system/page.tsx
+++ b/website/src/app/system/page.tsx
@@ -368,7 +368,7 @@ export default function SystemPage() {
         {viewMode === 'tech' && (
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
             <div className="grid md:grid-cols-2 gap-6">
-              {techStack.map((stack, idx) => (
+              {techStack.map((stack) => (
                 <TerminalWindow key={stack.category} title={stack.category.toUpperCase().replace(/ /g, '_')}>
                   <div className="space-y-2">
                     {stack.items.map((item) => (

--- a/website/src/app/transparency/page.tsx
+++ b/website/src/app/transparency/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { useI18n } from '@/lib/i18n';
-import { ApiClient, type StatusResponse } from '@/lib/api';
+import { ApiClient } from '@/lib/api';
 import { TerminalWindow } from '@/components/TerminalWindow';
 
 interface TransparencyStats {

--- a/website/src/components/DetailPageLayout.tsx
+++ b/website/src/components/DetailPageLayout.tsx
@@ -21,7 +21,7 @@ export function DetailPageLayout({
   error,
   children,
 }: DetailPageLayoutProps) {
-  const { t, locale } = useI18n();
+  const { locale } = useI18n();
 
   return (
     <div className="min-h-screen pt-14 py-8 px-4">

--- a/website/src/components/details/PipelineDetail.tsx
+++ b/website/src/components/details/PipelineDetail.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { useI18n } from '@/lib/i18n';
 import { ApiClient } from '@/lib/api';
+import type { ApiSignal, ApiTrend, ApiProject } from '@/lib/api';
 import { formatLocalDate } from '@/lib/date';
 import { clickableProps } from '@/lib/a11y';
 import type { ModalData } from '../modals/ModalProvider';
@@ -13,11 +14,26 @@ interface PipelineDetailProps {
   data: ModalData;
 }
 
+// Common shape shared by every item rendered in the recent-items list.
+// Signals/trends/projects are normalized to this; ideas/plans satisfy it directly.
+interface PipelineItem {
+  id: string;
+  title: string;
+  status: string;
+  created_at: string | null;
+}
+
+interface StageData {
+  items: PipelineItem[];
+  total: number;
+  statusCounts?: Record<string, number>;
+}
+
 export function PipelineDetail({ data }: PipelineDetailProps) {
   const router = useRouter();
   const { locale } = useI18n();
   const [loading, setLoading] = useState(true);
-  const [stageData, setStageData] = useState<any>(null);
+  const [stageData, setStageData] = useState<StageData | null>(null);
   const stageId = data.stageId as string;
   const stageName = data.stageName as string;
   const count = data.count as number;
@@ -31,7 +47,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
           const response = await ApiClient.getSignals({ limit: 5 });
           if (response.data) {
             setStageData({
-              items: response.data.signals.map((s: any) => ({
+              items: response.data.signals.map((s: ApiSignal) => ({
                 id: s.id,
                 title: s.title,
                 status: s.source,
@@ -44,7 +60,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
           const response = await ApiClient.getTrends();
           if (response.data) {
             setStageData({
-              items: response.data.trends.slice(0, 5).map((t: any) => ({
+              items: response.data.trends.slice(0, 5).map((t: ApiTrend) => ({
                 id: t.id,
                 title: t.name,
                 status: t.period,
@@ -74,7 +90,7 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
           const response = await ApiClient.getProjects({ limit: 5 });
           if (response.data) {
             setStageData({
-              items: response.data.projects.map((p: any) => ({
+              items: response.data.projects.map((p: ApiProject) => ({
                 id: p.id,
                 title: p.name,
                 status: p.status,
@@ -146,12 +162,12 @@ export function PipelineDetail({ data }: PipelineDetailProps) {
       </div>
 
       {/* Recent Items */}
-      {stageData?.items?.length > 0 && (
+      {(stageData?.items?.length ?? 0) > 0 && (
         <div className="space-y-2">
           <div className="text-[10px] text-[#8b949e] uppercase tracking-wider">
             Recent {stageName}
           </div>
-          {stageData.items.map((item: any, idx: number) => (
+          {stageData?.items?.map((item: PipelineItem, idx: number) => (
             <motion.div
               key={item.id}
               initial={{ opacity: 0, x: -10 }}

--- a/website/src/components/details/StatsDetail.tsx
+++ b/website/src/components/details/StatsDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { ApiClient } from '@/lib/api';
+import { ApiClient, type StatusResponse } from '@/lib/api';
 import type { ModalData } from '../modals/ModalProvider';
 
 interface StatsDetailProps {
@@ -33,7 +33,7 @@ interface UsageData {
 export function StatsDetail({ data }: StatsDetailProps) {
   const [loading, setLoading] = useState(true);
   const [usage, setUsage] = useState<UsageData | null>(null);
-  const [statusData, setStatusData] = useState<any>(null);
+  const [statusData, setStatusData] = useState<StatusResponse | null>(null);
 
   useEffect(() => {
     async function fetchData() {

--- a/website/src/components/details/TrendDetail.tsx
+++ b/website/src/components/details/TrendDetail.tsx
@@ -147,19 +147,19 @@ export function TrendDetail({ data }: TrendDetailProps) {
       )}
 
       {/* Web3 Relevance */}
-      {(trend as any).web3_relevance && (
+      {trend.web3_relevance && (
         <div className="card-cli p-4 border-l-2 border-[#bd93f9]">
           <div className="text-xs text-[#8b949e] uppercase mb-2">Web3 Relevance</div>
-          <p className="text-sm text-[#c0c0c0] leading-relaxed">{(trend as any).web3_relevance}</p>
+          <p className="text-sm text-[#c0c0c0] leading-relaxed">{trend.web3_relevance}</p>
         </div>
       )}
 
       {/* Idea Seeds */}
-      {(trend as any).idea_seeds && (trend as any).idea_seeds.length > 0 && (
+      {trend.idea_seeds && trend.idea_seeds.length > 0 && (
         <div className="card-cli p-4">
           <div className="text-xs text-[#8b949e] uppercase mb-2">💡 Idea Seeds</div>
           <div className="space-y-2">
-            {(trend as any).idea_seeds.map((seed: string, idx: number) => (
+            {trend.idea_seeds.map((seed, idx) => (
               <motion.div
                 key={idx}
                 initial={{ opacity: 0, x: -10 }}
@@ -176,11 +176,11 @@ export function TrendDetail({ data }: TrendDetailProps) {
       )}
 
       {/* Sample Headlines */}
-      {(trend as any).sample_headlines && (trend as any).sample_headlines.length > 0 && (
+      {trend.sample_headlines && trend.sample_headlines.length > 0 && (
         <div className="card-cli p-4">
           <div className="text-xs text-[#8b949e] uppercase mb-2">📰 Sample Headlines</div>
           <div className="space-y-2">
-            {(trend as any).sample_headlines.map((headline: string, idx: number) => (
+            {trend.sample_headlines.map((headline, idx) => (
               <motion.div
                 key={idx}
                 initial={{ opacity: 0, x: -10 }}
@@ -216,11 +216,11 @@ export function TrendDetail({ data }: TrendDetailProps) {
       )}
 
       {/* Sources */}
-      {(trend as any).sources && (trend as any).sources.length > 0 && (
+      {trend.sources && trend.sources.length > 0 && (
         <div className="card-cli p-4">
           <div className="text-xs text-[#8b949e] uppercase mb-2">Sources</div>
           <div className="flex flex-wrap gap-2">
-            {(trend as any).sources.map((source: string, idx: number) => (
+            {trend.sources.map((source, idx) => (
               <span
                 key={idx}
                 className="tag tag-cyan"

--- a/website/src/components/pages/IdeaDetailPage.tsx
+++ b/website/src/components/pages/IdeaDetailPage.tsx
@@ -11,7 +11,7 @@ interface IdeaDetailPageProps {
 }
 
 export function IdeaDetailPage({ id }: IdeaDetailPageProps) {
-  const { t, locale } = useI18n();
+  const { locale } = useI18n();
   const [idea, setIdea] = useState<ApiIdea | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/website/src/components/pages/PlanDetailPage.tsx
+++ b/website/src/components/pages/PlanDetailPage.tsx
@@ -11,7 +11,7 @@ interface PlanDetailPageProps {
 }
 
 export function PlanDetailPage({ id }: PlanDetailPageProps) {
-  const { t, locale } = useI18n();
+  const { locale } = useI18n();
   const [plan, setPlan] = useState<ApiPlan | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/website/src/components/pages/SignalDetailPage.tsx
+++ b/website/src/components/pages/SignalDetailPage.tsx
@@ -11,7 +11,7 @@ interface SignalDetailPageProps {
 }
 
 export function SignalDetailPage({ id }: SignalDetailPageProps) {
-  const { t, locale } = useI18n();
+  const { locale } = useI18n();
   const [signal, setSignal] = useState<ApiSignal | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/website/src/components/visualization/AgentContribution.tsx
+++ b/website/src/components/visualization/AgentContribution.tsx
@@ -277,7 +277,7 @@ export function AgentContribution({
               </div>
 
               <p className="text-xs text-[#8b949e] italic leading-relaxed line-clamp-2">
-                "{agent.keyQuote}"
+                &quot;{agent.keyQuote}&quot;
               </p>
             </motion.div>
           ))}

--- a/website/src/components/visualization/IdeaNetwork.tsx
+++ b/website/src/components/visualization/IdeaNetwork.tsx
@@ -45,7 +45,10 @@ export function IdeaNetwork({ ideas, onIdeaClick, showLabels = true }: IdeaNetwo
 
     ideas.forEach((idea, index) => {
       const angle = (index / ideas.length) * 2 * Math.PI - Math.PI / 2;
-      const r = radius * (0.6 + Math.random() * 0.4);
+      // Deterministic per-node radial jitter (stable across renders, no impure
+      // Math.random in render): hash the index into the [0, 1) range.
+      const jitter = ((Math.sin(index * 12.9898) * 43758.5453) % 1 + 1) % 1;
+      const r = radius * (0.6 + jitter * 0.4);
 
       nodes.push({
         id: idea.id,

--- a/website/src/components/visualization/TrendHeatmap.tsx
+++ b/website/src/components/visualization/TrendHeatmap.tsx
@@ -44,9 +44,13 @@ export function TrendHeatmap({ trends, onCellClick }: TrendHeatmapProps) {
         cat => trend.category?.toLowerCase().includes(cat.toLowerCase())
       ) || 'Other';
 
+      // When a trend has no analyzed_at date, derive a stable day bucket from
+      // its id so rendering stays pure and idempotent (no Math.random()).
+      const fallbackDayIndex =
+        Array.from(trend.id).reduce((acc, ch) => acc + ch.charCodeAt(0), 0) % 7;
       const dayIndex = trend.analyzed_at
         ? new Date(trend.analyzed_at).getDay()
-        : Math.floor(Math.random() * 7);
+        : fallbackDayIndex;
       const day = DAYS[dayIndex === 0 ? 6 : dayIndex - 1]; // Convert Sunday=0 to index 6
 
       if (grouped[category] && grouped[category][day]) {

--- a/website/src/data/mock.ts
+++ b/website/src/data/mock.ts
@@ -23,7 +23,7 @@ export const mockActivity: ActivityItem[] = [
   { time: '08:05', type: 'debate', message: 'VC feedback received (GPT) - market concerns' },
   { time: '08:06', type: 'debate', message: 'Accelerator feedback (Gemini) - MVP scope' },
   { time: '08:07', type: 'plan', message: 'Plan #4 finalized after 3 debate rounds' },
-  { time: '08:08', type: 'system', message: 'Cycle completed. Next run: 2026-01-06 08:00 KST' },
+  { time: '08:08', type: 'system', message: 'Cycle completed. Next run in ~6h (debate cycle)' },
 ];
 
 export const mockTrends: Trend[] = [

--- a/website/src/lib/api.ts
+++ b/website/src/lib/api.ts
@@ -198,7 +198,7 @@ export interface ApiDebate {
   summary: string | null;
   outcome: string | null;
   final_plan: string | null;
-  ideas_generated: any[];
+  ideas_generated: Record<string, unknown>[];
   total_tokens: number;
   total_cost: number;
   started_at: string | null;


### PR DESCRIPTION
## Summary
The frontend has **no lint CI gate** and had accumulated **30 ESLint problems** (23 errors, 7 warnings) across 15 files. All fixed with **real fixes** — no `eslint-disable`, no `@ts-ignore`, no new `any` (each per-file fix was fanned out and verified eslint-clean).

| Rule | Count | Fix |
|---|---|---|
| `@typescript-eslint/no-explicit-any` | 18 | Typed against real shapes from `lib/api`/`lib/types` (`ApiSignal`/`ApiTrend`/`ApiProject`/`StatusResponse`, `ApiTrend`'s optional analysis fields, `Record<string, unknown>` for the JSON `ideas_generated` column) + small local interfaces in `PipelineDetail`. |
| `react-hooks/purity` | 2 | `IdeaNetwork`/`TrendHeatmap` called `Math.random()` in the render body → replaced with a deterministic hash of the node index / trend id inside the existing `useMemo` (stable layout, equivalent look). |
| `react-hooks/set-state-in-effect` | 1 | `/debates` derives `loading` from `debates === null` and folds the initial fetch into the polling effect (no synchronous setState in an effect). |
| `react/no-unescaped-entities` | 2 | Escaped quotes. |
| `no-unused-vars` | 7 | Dropped unused imports/vars/map-indices. |

Also de-staled one demo activity-log line (`"Next run: 2026-01-06 08:00 KST"` → `"Next run in ~6h"`).

## Verification
- **`npx eslint src` → 0 problems** (was 30).
- **`npm run build` passes** — full cross-file type-check is green after removing every `any`.
- `/debates` (the set-state refactor) renders with **no console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)